### PR TITLE
Enable 4kSquares mode for any 4k resolutions

### DIFF
--- a/gst-plugin/aja/gstntv2.cpp
+++ b/gst-plugin/aja/gstntv2.cpp
@@ -644,6 +644,10 @@ AJAStatus NTV2GstAV::SetupVideo (void)
   mDevice.SetMode (mInputChannel, NTV2_MODE_CAPTURE, false);
   mDevice.SetFrameBufferFormat (mInputChannel, mPixelFormat);
 
+  if (mQuad) {
+    mDevice.Set4kSquaresEnable(true, (NTV2Channel) mInputChannel);
+  }
+
   mDevice.EnableChannel (mInputChannel);
 
   //    Setup frame buffer


### PR DESCRIPTION
SDK version 15 defaults to TSI but we currently, and before, only handle
quad mode for 4k resolutions.