### PR TITLE
ajavideosrc: Don't report that we have signal until we know for sure

### DIFF
--- a/gst-plugin/aja/gstajaaudiosrc.cpp
+++ b/gst-plugin/aja/gstajaaudiosrc.cpp
@@ -662,7 +662,7 @@ gst_aja_audio_src_got_packet (GstAjaAudioSrc * src, AjaAudioBuff * audioBuff)
   GstClockTime stream_time, timestamp;
 
   // Just return if we have no signal
-  if (!audioBuff || (!audioBuff->haveSignal && src->have_signal)) {
+  if (!audioBuff || !audioBuff->haveSignal) {
     if (audioBuff)
       src->input->ntv2AVHevc->ReleaseAudioBuffer (audioBuff);
     return;

--- a/gst-plugin/aja/gstajaaudiosrc.h
+++ b/gst-plugin/aja/gstajaaudiosrc.h
@@ -57,8 +57,6 @@ struct _GstAjaAudioSrc
     guint                       channels;
     guint                       queue_size;
     guint64                     next_offset;
-    gboolean                    have_signal;
-
 };
 
 struct _GstAjaAudioSrcClass

--- a/gst-plugin/aja/gstajavideosrc.h
+++ b/gst-plugin/aja/gstajavideosrc.h
@@ -40,6 +40,12 @@ G_BEGIN_DECLS
 typedef struct _GstAjaVideoSrc GstAjaVideoSrc;
 typedef struct _GstAjaVideoSrcClass GstAjaVideoSrcClass;
 
+typedef enum {
+  SIGNAL_STATE_UNKNOWN,
+  SIGNAL_STATE_LOST,
+  SIGNAL_STATE_AVAILABLE,
+} GstAjaSignalState;
+
 struct _GstAjaVideoSrc
 {
     GstPushSrc                  parent;
@@ -65,7 +71,7 @@ struct _GstAjaVideoSrc
     gboolean                    output_cc;
     gint			last_cc_vbi_line;
 
-    gboolean have_signal;
+    GstAjaSignalState signal_state;
     GstClockTime discont_time;
     guint64 discont_frame_number;
 


### PR DESCRIPTION
    Previously we would've reported that there is signal unless we know for
    sure that we don't have signal. For example signal would've been
    reported before the device is even opened.
    
    Now keep track whether the signal state is unknown or not and report no
    signal if we don't know yet. As before, only send an INFO message about
    signal recovery if we actually had a signal loss before.
