### PR TITLE
Consider it a discontinuity if we got the first frame after signal lo…

### DIFF
--- a/gst-plugin/aja/gstajaaudiosrc.h
+++ b/gst-plugin/aja/gstajaaudiosrc.h
@@ -57,6 +57,7 @@ struct _GstAjaAudioSrc
     guint                       channels;
     guint                       queue_size;
     guint64                     next_offset;
+    gboolean                    had_signal;
 };
 
 struct _GstAjaAudioSrcClass


### PR DESCRIPTION
…ss in the audio source

Otherwise the audio source will continue counting samples for the
timestamp from the time when the signal loss happened, causing A/V sync
to be off.