### PR TITLE
Add NVMM RDMA support for NVIDIA GPU buffer output

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,30 @@ Test the gst plugin:
     export GST_PLUGIN_PATH=/usr/local/lib/gstreamer-1.0
     gst-launch-1.0 ajavideosrc ! videoconvert ! autovideosink
 
+## NVIDIA RDMA Support
+
+This plugin includes optional support for outputting video frames directly
+to NVIDIA GPU memory via NVMM buffers using RDMA. Enabling this support
+requires the [NVIDIA CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit)
+and [DeepStream](https://developer.nvidia.com/deepstream-sdk) to be installed,
+and the AJA NTV2 drivers must be compiled with the `AJA_RDMA` flag enabled.
+
+To enable NVMM RDMA support in this plugin, the `GST_CUDA` and `GST_DEEPSTREAM`
+environment variables must be set to the CUDA and DeepStream install paths
+before running `./autogen.sh` in the build steps above. For example:
+
+    export GST_CUDA=/usr/local/cuda-11.1/targets/sbsa-linux
+    export GST_DEEPSTREAM=/opt/nvidia/deepstream/deepstream-5.1
+
+When compiled with NVMM RDMA support, the `nvmm` boolean option is added to the
+`ajavideosrc` plugin in order to enable NVMM RDMA buffer outputs. Testing NVMM
+RDMA output can be done using the following:
+
+    gst-launch-1.0 ajavideosrc mode=4Kp60-rgba nvmm=true ! nv3dsink
+
+Note that the NVIDIA GStreamer plugins provided by DeepStream do not support
+packed YUV formats, and so the use of an RGBA mode is required.
+
 ## License
 
 Copyright 2016 AJA Video Systems Inc. All rights reserved.

--- a/gst-plugin/aja/Makefile.am
+++ b/gst-plugin/aja/Makefile.am
@@ -15,6 +15,13 @@ libgstaja_la_CPPFLAGS = \
 	-I$(GST_NTV2)/ajalibraries/ajabase \
 	-I$(GST_NTV2)/ajalibraries
 
+if ENABLE_NVMM
+libgstaja_la_CPPFLAGS += \
+	-DENABLE_NVMM \
+	-I$(GST_DEEPSTREAM)/sources/includes \
+	-I$(GST_CUDA)/include
+endif
+
 libgstaja_la_LIBADD = \
 	-L$(GST_NTV2)/lib \
 	$(GST_PLUGINS_BASE_LIBS) \
@@ -26,6 +33,13 @@ libgstaja_la_LIBADD = \
 	$(GST_BASE_LIBS) \
 	$(GST_LIBS) \
 	$(LIBM)
+
+if ENABLE_NVMM
+libgstaja_la_LIBADD += \
+	-L$(GST_DEEPSTREAM)/lib \
+	-lnvdsbufferpool \
+	-lcuda
+endif
 
 libgstaja_la_LDFLAGS = -std=c++11 $(GST_PLUGIN_LDFLAGS)
 libgstaja_la_LIBTOOLFLAGS = $(GST_PLUGIN_LIBTOOLFLAGS)

--- a/gst-plugin/aja/gstaja.cpp
+++ b/gst-plugin/aja/gstaja.cpp
@@ -1,6 +1,7 @@
 /* GStreamer
  * Copyright (C) 2015 PSM <philm@aja.com>
  * Copyright (C) 2017 Sebastian Dröge <sebastian@centricular.com>
+ * Copyright (C) 2021 NVIDIA Corporation.  All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -96,137 +97,182 @@ gst_aja_acquire_input (const gchar * inDeviceSpecifier, gint channel,
 #define PAL     12, 11, true,   "bt601"
 #define HD      1,  1,  true,   "bt709"
 #define UHD     1,  1,  true,   "bt2020"
+#define YUV     (false)
+#define RGBA    (true)
 
 static const GstAjaMode modesRaw[GST_AJA_MODE_RAW_END] =
 {
-    {NTV2_FORMAT_525_2398,          720,    486,    8,  24000,    1001, true,   true,    NTSC},  // GST_AJA_MODE_RAW_NTSC_8_2398i
-    {NTV2_FORMAT_525_2400,          720,    486,    8,  24,       1,    true,   true,    NTSC},  // GST_AJA_MODE_RAW_NTSC_8_24i
-    {NTV2_FORMAT_525_5994,          720,    486,    8,  30000,    1001, true,   true,    NTSC},  // GST_AJA_MODE_RAW_NTSC_8_5994i
-    {NTV2_FORMAT_525_2398,          720,    486,    10, 24000,    1001, true,   true,    NTSC},  // GST_AJA_MODE_RAW_NTSC_10_2398i
-    {NTV2_FORMAT_525_2400,          720,    486,    10, 24,       1,    true,   true,    NTSC},  // GST_AJA_MODE_RAW_NTSC_10_24i
-    {NTV2_FORMAT_525_5994,          720,    486,    10, 30000,    1001, true,   true,    NTSC},  // GST_AJA_MODE_RAW_NTSC_10_5994i
-    
-    {NTV2_FORMAT_625_5000,          720,    486,    8,  25,       1,    true,   true,    PAL},   // GST_AJA_MODE_RAW_PAL_8_50i
-    {NTV2_FORMAT_625_5000,          720,    486,    10, 25,       1,    true,   true,    PAL},   // GST_AJA_MODE_RAW_PAL_10_50i
-    
-    {NTV2_FORMAT_720p_2398,         1280,   720,    8,  24000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_720_8_2398p
-    {NTV2_FORMAT_720p_2500,         1280,   720,    8,  25,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_720_8_25p
-    {NTV2_FORMAT_720p_5000,         1280,   720,    8,  50,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_720_8_50p
-    {NTV2_FORMAT_720p_5994,         1280,   720,    8,  60000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_720_8_5994p
-    {NTV2_FORMAT_720p_6000,         1280,   720,    8,  60,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_720_8_60p
-    {NTV2_FORMAT_720p_2398,         1280,   720,    10, 2400,     1001, false,  true,    HD},    // GST_AJA_MODE_RAW_720_10_2398p
-    {NTV2_FORMAT_720p_2500,         1280,   720,    10, 25,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_720_10_25p
-    {NTV2_FORMAT_720p_5000,         1280,   720,    10, 50,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_720_10_50p
-    {NTV2_FORMAT_720p_5994,         1280,   720,    10, 60000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_720_10_5994p
-    {NTV2_FORMAT_720p_6000,         1280,   720,    10, 60,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_720_10_60p
-    
-    {NTV2_FORMAT_1080p_2398,        1920,   1080,   8,  24000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_2398p
-    {NTV2_FORMAT_1080p_2400,        1920,   1080,   8,  24,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_24p
-    {NTV2_FORMAT_1080p_2500,        1920,   1080,   8,  25,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_25p
-    {NTV2_FORMAT_1080p_2997,        1920,   1080,   8,  30000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_2997p
-    {NTV2_FORMAT_1080p_3000,        1920,   1080,   8,  30,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_30p
-    {NTV2_FORMAT_1080i_5000,        1920,   1080,   8,  25,       1,    true,   true,    HD},    // GST_AJA_MODE_RAW_1080_8_50i
-    {NTV2_FORMAT_1080p_5000_A,      1920,   1080,   8,  50,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_50p
-    {NTV2_FORMAT_1080i_5994,        1920,   1080,   8,  30000,    1001, true,   true,    HD},    // GST_AJA_MODE_RAW_1080_8_5994i
-    {NTV2_FORMAT_1080p_5994_A,      1920,   1080,   8,  60000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_5994p
-    {NTV2_FORMAT_1080i_6000,        1920,   1080,   8,  30,       1,    true,   true,    HD},    // GST_AJA_MODE_RAW_1080_8_60i
-    {NTV2_FORMAT_1080p_6000_A,      1920,   1080,   8,  60,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_60p
-    
-    {NTV2_FORMAT_1080p_2398,        1920,   1080,   10, 24000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_1080_10_2398p
-    {NTV2_FORMAT_1080p_2400,        1920,   1080,   10, 24,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_10_24p
-    {NTV2_FORMAT_1080p_2500,        1920,   1080,   10, 25,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_10_25p
-    {NTV2_FORMAT_1080p_2997,        1920,   1080,   10, 30000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_1080_10_2997p
-    {NTV2_FORMAT_1080p_3000,        1920,   1080,   10, 30,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_10_30p
-    {NTV2_FORMAT_1080i_5000,        1920,   1080,   10, 25,       1,    true,   true,    HD},    // GST_AJA_MODE_RAW_1080_10_50i
-    {NTV2_FORMAT_1080p_5000_A,      1920,   1080,   10, 50,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_10_50p
-    {NTV2_FORMAT_1080i_5994,        1920,   1080,   10, 30000,    1001, true,   true,    HD},    // GST_AJA_MODE_RAW_1080_10_5994i
-    {NTV2_FORMAT_1080p_5994_A,      1920,   1080,   10, 60000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_1080_10_5994p
-    {NTV2_FORMAT_1080i_6000,        1920,   1080,   10, 30,       1,    true,   true,    HD},    // GST_AJA_MODE_RAW_1080_10_60i
-    {NTV2_FORMAT_1080p_6000_A,      1920,   1080,   10, 60,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_10_60p
-    
-    {NTV2_FORMAT_3840x2160p_2398, 3840,   2160,   8,  24000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_2398p
-    {NTV2_FORMAT_3840x2160p_2400, 3840,   2160,   8,  24,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_24p
-    {NTV2_FORMAT_3840x2160p_2500, 3840,   2160,   8,  25,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_25p
-    {NTV2_FORMAT_3840x2160p_2997, 3840,   2160,   8,  30000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_2997p
-    {NTV2_FORMAT_3840x2160p_3000, 3840,   2160,   8,  30,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_30p
-    {NTV2_FORMAT_3840x2160p_5000, 3840,   2160,   8,  50,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_50p
-    {NTV2_FORMAT_3840x2160p_5994, 3840,   2160,   8,  60000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_5994p
-    {NTV2_FORMAT_3840x2160p_6000, 3840,   2160,   8,  60,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_60p
-    
-    {NTV2_FORMAT_3840x2160p_2398, 3840,   2160,   10, 24000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_10_2398p
-    {NTV2_FORMAT_3840x2160p_2400, 3840,   2160,   10, 24,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_10_24p
-    {NTV2_FORMAT_3840x2160p_2500, 3840,   2160,   10, 25,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_10_25p
-    {NTV2_FORMAT_3840x2160p_2997, 3840,   2160,   10, 30000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_10_2997p
-    {NTV2_FORMAT_3840x2160p_3000, 3840,   2160,   10, 30,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_10_30p
-    {NTV2_FORMAT_3840x2160p_5000, 3840,   2160,   10, 50,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_10_50p
-    {NTV2_FORMAT_3840x2160p_5994, 3840,   2160,   10, 60000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_10_5994p
-    {NTV2_FORMAT_3840x2160p_6000, 3840,   2160,   10, 60,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_10_60p
-    
-    {NTV2_FORMAT_4096x2160p_2398, 4096,   2160,   8,  24000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_2398p
-    {NTV2_FORMAT_4096x2160p_2400, 4096,   2160,   8,  24,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_24p
-    {NTV2_FORMAT_4096x2160p_2500, 4096,   2160,   8,  25,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_25p
-    {NTV2_FORMAT_4096x2160p_2997, 4096,   2160,   8,  30000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_2997p
-    {NTV2_FORMAT_4096x2160p_3000, 4096,   2160,   8,  30,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_30p
-    {NTV2_FORMAT_4096x2160p_4795, 4096,   2160,   8,  48000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_4795p
-    {NTV2_FORMAT_4096x2160p_4800, 4096,   2160,   8,  48,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_48p
-    {NTV2_FORMAT_4096x2160p_5000, 4096,   2160,   8,  50,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_50p
-    {NTV2_FORMAT_4096x2160p_5994, 4096,   2160,   8,  60000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_5994p
-    {NTV2_FORMAT_4096x2160p_6000, 4096,   2160,   8,  60,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_60p
-    {NTV2_FORMAT_4096x2160p_11988, 4096,   2160,  8,  120000,   1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_11988p
-    {NTV2_FORMAT_4096x2160p_12000, 4096,   2160,  8,  120,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_120p
-    
-    {NTV2_FORMAT_4096x2160p_2398, 4096,   2160,   10, 24000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_2398p
-    {NTV2_FORMAT_4096x2160p_2400, 4096,   2160,   10, 24,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_24p
-    {NTV2_FORMAT_4096x2160p_2500, 4096,   2160,   10, 25,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_25p
-    {NTV2_FORMAT_4096x2160p_2997, 4096,   2160,   10, 30000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_2997p
-    {NTV2_FORMAT_4096x2160p_3000, 4096,   2160,   10, 30,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_30p
-    {NTV2_FORMAT_4096x2160p_4795, 4096,   2160,   10, 48000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_4795p
-    {NTV2_FORMAT_4096x2160p_4800, 4096,   2160,   10, 48,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_48p
-    {NTV2_FORMAT_4096x2160p_5000, 4096,   2160,   10, 50,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_50p
-    {NTV2_FORMAT_4096x2160p_5994, 4096,   2160,   10, 60000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_5994p
-    {NTV2_FORMAT_4096x2160p_6000, 4096,   2160,   10, 60,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_60p
-    {NTV2_FORMAT_4096x2160p_11988, 4096,  2160,   10, 120000,   1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_11988p
-    {NTV2_FORMAT_4096x2160p_12000, 4096,  2160,   10, 120,      1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_120p
-    
-    {NTV2_FORMAT_4x3840x2160p_2398, 7680,   4320,   8,  24000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_8_2398p
-    {NTV2_FORMAT_4x3840x2160p_2400, 7680,   4320,   8,  24,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_8_24p
-    {NTV2_FORMAT_4x3840x2160p_2500, 7680,   4320,   8,  25,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_8_25p
-    {NTV2_FORMAT_4x3840x2160p_2997, 7680,   4320,   8,  30000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_8_2997p
-    {NTV2_FORMAT_4x3840x2160p_3000, 7680,   4320,   8,  30,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_8_30p
-    {NTV2_FORMAT_4x3840x2160p_5000, 7680,   4320,   8,  50,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_8_50p
-    {NTV2_FORMAT_4x3840x2160p_5994, 7680,   4320,   8,  60000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_8_5994p
-    {NTV2_FORMAT_4x3840x2160p_6000, 7680,   4320,   8,  60,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_8_60p
-    
-    {NTV2_FORMAT_4x3840x2160p_2398, 7680,   4320,   10, 24000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_10_2398p
-    {NTV2_FORMAT_4x3840x2160p_2400, 7680,   4320,   10, 24,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_10_24p
-    {NTV2_FORMAT_4x3840x2160p_2500, 7680,   4320,   10, 25,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_10_25p
-    {NTV2_FORMAT_4x3840x2160p_2997, 7680,   4320,   10, 30000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_10_2997p
-    {NTV2_FORMAT_4x3840x2160p_3000, 7680,   4320,   10, 30,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_10_30p
-    {NTV2_FORMAT_4x3840x2160p_5000, 7680,   4320,   10, 50,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_10_50p
-    {NTV2_FORMAT_4x3840x2160p_5994, 7680,   4320,   10, 60000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_10_5994p
-    {NTV2_FORMAT_4x3840x2160p_6000, 7680,   4320,   10, 60,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_10_60p
-    
-    {NTV2_FORMAT_4x4096x2160p_2398, 8192,   4320,   8,  24000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_8_2398p
-    {NTV2_FORMAT_4x4096x2160p_2400, 8192,   4320,   8,  24,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_8_24p
-    {NTV2_FORMAT_4x4096x2160p_2500, 8192,   4320,   8,  25,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_8_25p
-    {NTV2_FORMAT_4x4096x2160p_2997, 8192,   4320,   8,  30000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_8_2997p
-    {NTV2_FORMAT_4x4096x2160p_3000, 8192,   4320,   8,  30,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_8_30p
-    {NTV2_FORMAT_4x4096x2160p_4795, 8192,   4320,   8,  48000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_8_4795p
-    {NTV2_FORMAT_4x4096x2160p_4800, 8192,   4320,   8,  48,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_8_48p
-    {NTV2_FORMAT_4x4096x2160p_5000, 8192,   4320,   8,  50,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_8_50p
-    {NTV2_FORMAT_4x4096x2160p_5994, 8192,   4320,   8,  60000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_8_5994p
-    {NTV2_FORMAT_4x4096x2160p_6000, 8192,   4320,   8,  60,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_8_60p
-    
-    {NTV2_FORMAT_4x4096x2160p_2398, 8192,   4320,   10, 24000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_10_2398p
-    {NTV2_FORMAT_4x4096x2160p_2400, 8192,   4320,   10, 24,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_10_24p
-    {NTV2_FORMAT_4x4096x2160p_2500, 8192,   4320,   10, 25,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_10_25p
-    {NTV2_FORMAT_4x4096x2160p_2997, 8192,   4320,   10, 30000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_10_2997p
-    {NTV2_FORMAT_4x4096x2160p_3000, 8192,   4320,   10, 30,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_10_30p
-    {NTV2_FORMAT_4x4096x2160p_4795, 8192,   4320,   10, 48000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_10_4795p
-    {NTV2_FORMAT_4x4096x2160p_4800, 8192,   4320,   10, 48,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_10_48p
-    {NTV2_FORMAT_4x4096x2160p_5000, 8192,   4320,   10, 50,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_10_50p
-    {NTV2_FORMAT_4x4096x2160p_5994, 8192,   4320,   10, 60000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_10_5994p
-    {NTV2_FORMAT_4x4096x2160p_6000, 8192,   4320,   10, 60,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_10_60p
+    {NTV2_FORMAT_525_2398,          720,    486,    8,  YUV,  24000,    1001, true,   true,    NTSC},  // GST_AJA_MODE_RAW_NTSC_8_2398i
+    {NTV2_FORMAT_525_2400,          720,    486,    8,  YUV,  24,       1,    true,   true,    NTSC},  // GST_AJA_MODE_RAW_NTSC_8_24i
+    {NTV2_FORMAT_525_5994,          720,    486,    8,  YUV,  30000,    1001, true,   true,    NTSC},  // GST_AJA_MODE_RAW_NTSC_8_5994i
+    {NTV2_FORMAT_525_2398,          720,    486,    8,  RGBA, 24000,    1001, true,   true,    NTSC},  // GST_AJA_MODE_RAW_NTSC_8_RGBA_2398i
+    {NTV2_FORMAT_525_2400,          720,    486,    8,  RGBA, 24,       1,    true,   true,    NTSC},  // GST_AJA_MODE_RAW_NTSC_8_RGBA_24i
+    {NTV2_FORMAT_525_5994,          720,    486,    8,  RGBA, 30000,    1001, true,   true,    NTSC},  // GST_AJA_MODE_RAW_NTSC_8_RGBA_5994i
+    {NTV2_FORMAT_525_2398,          720,    486,    10, YUV,  24000,    1001, true,   true,    NTSC},  // GST_AJA_MODE_RAW_NTSC_10_2398i
+    {NTV2_FORMAT_525_2400,          720,    486,    10, YUV,  24,       1,    true,   true,    NTSC},  // GST_AJA_MODE_RAW_NTSC_10_24i
+    {NTV2_FORMAT_525_5994,          720,    486,    10, YUV,  30000,    1001, true,   true,    NTSC},  // GST_AJA_MODE_RAW_NTSC_10_5994i
+
+    {NTV2_FORMAT_625_5000,          720,    486,    8,  YUV,  25,       1,    true,   true,    PAL},   // GST_AJA_MODE_RAW_PAL_8_50i
+    {NTV2_FORMAT_625_5000,          720,    486,    8,  RGBA, 25,       1,    true,   true,    PAL},   // GST_AJA_MODE_RAW_PAL_8_RGBA_50i
+    {NTV2_FORMAT_625_5000,          720,    486,    10, YUV,  25,       1,    true,   true,    PAL},   // GST_AJA_MODE_RAW_PAL_10_50i
+
+    {NTV2_FORMAT_720p_2398,         1280,   720,    8,  YUV,  24000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_720_8_2398p
+    {NTV2_FORMAT_720p_2500,         1280,   720,    8,  YUV,  25,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_720_8_25p
+    {NTV2_FORMAT_720p_5000,         1280,   720,    8,  YUV,  50,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_720_8_50p
+    {NTV2_FORMAT_720p_5994,         1280,   720,    8,  YUV,  60000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_720_8_5994p
+    {NTV2_FORMAT_720p_6000,         1280,   720,    8,  YUV,  60,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_720_8_60p
+    {NTV2_FORMAT_720p_2398,         1280,   720,    8,  RGBA, 24000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_720_8_RGBA_2398p
+    {NTV2_FORMAT_720p_2500,         1280,   720,    8,  RGBA, 25,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_720_8_RGBA_25p
+    {NTV2_FORMAT_720p_5000,         1280,   720,    8,  RGBA, 50,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_720_8_RGBA_50p
+    {NTV2_FORMAT_720p_5994,         1280,   720,    8,  RGBA, 60000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_720_8_RGBA_5994p
+    {NTV2_FORMAT_720p_6000,         1280,   720,    8,  RGBA, 60,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_720_8_RGBA_60p
+    {NTV2_FORMAT_720p_2398,         1280,   720,    10, YUV,  2400,     1001, false,  true,    HD},    // GST_AJA_MODE_RAW_720_10_2398p
+    {NTV2_FORMAT_720p_2500,         1280,   720,    10, YUV,  25,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_720_10_25p
+    {NTV2_FORMAT_720p_5000,         1280,   720,    10, YUV,  50,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_720_10_50p
+    {NTV2_FORMAT_720p_5994,         1280,   720,    10, YUV,  60000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_720_10_5994p
+    {NTV2_FORMAT_720p_6000,         1280,   720,    10, YUV,  60,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_720_10_60p
+
+    {NTV2_FORMAT_1080p_2398,        1920,   1080,   8,  YUV,  24000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_2398p
+    {NTV2_FORMAT_1080p_2400,        1920,   1080,   8,  YUV,  24,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_24p
+    {NTV2_FORMAT_1080p_2500,        1920,   1080,   8,  YUV,  25,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_25p
+    {NTV2_FORMAT_1080p_2997,        1920,   1080,   8,  YUV,  30000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_2997p
+    {NTV2_FORMAT_1080p_3000,        1920,   1080,   8,  YUV,  30,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_30p
+    {NTV2_FORMAT_1080i_5000,        1920,   1080,   8,  YUV,  25,       1,    true,   true,    HD},    // GST_AJA_MODE_RAW_1080_8_50i
+    {NTV2_FORMAT_1080p_5000_A,      1920,   1080,   8,  YUV,  50,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_50p
+    {NTV2_FORMAT_1080i_5994,        1920,   1080,   8,  YUV,  30000,    1001, true,   true,    HD},    // GST_AJA_MODE_RAW_1080_8_5994i
+    {NTV2_FORMAT_1080p_5994_A,      1920,   1080,   8,  YUV,  60000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_5994p
+    {NTV2_FORMAT_1080i_6000,        1920,   1080,   8,  YUV,  30,       1,    true,   true,    HD},    // GST_AJA_MODE_RAW_1080_8_60i
+    {NTV2_FORMAT_1080p_6000_A,      1920,   1080,   8,  YUV,  60,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_60p
+
+    {NTV2_FORMAT_1080p_2398,        1920,   1080,   8,  RGBA, 24000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_RGBA_2398p
+    {NTV2_FORMAT_1080p_2400,        1920,   1080,   8,  RGBA, 24,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_RGBA_24p
+    {NTV2_FORMAT_1080p_2500,        1920,   1080,   8,  RGBA, 25,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_RGBA_25p
+    {NTV2_FORMAT_1080p_2997,        1920,   1080,   8,  RGBA, 30000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_RGBA_2997p
+    {NTV2_FORMAT_1080p_3000,        1920,   1080,   8,  RGBA, 30,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_RGBA_30p
+    {NTV2_FORMAT_1080i_5000,        1920,   1080,   8,  RGBA, 25,       1,    true,   true,    HD},    // GST_AJA_MODE_RAW_1080_8_RGBA_50i
+    {NTV2_FORMAT_1080p_5000_A,      1920,   1080,   8,  RGBA, 50,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_RGBA_50p
+    {NTV2_FORMAT_1080i_5994,        1920,   1080,   8,  RGBA, 30000,    1001, true,   true,    HD},    // GST_AJA_MODE_RAW_1080_8_RGBA_5994i
+    {NTV2_FORMAT_1080p_5994_A,      1920,   1080,   8,  RGBA, 60000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_RGBA_5994p
+    {NTV2_FORMAT_1080i_6000,        1920,   1080,   8,  RGBA, 30,       1,    true,   true,    HD},    // GST_AJA_MODE_RAW_1080_8_RGBA_60i
+    {NTV2_FORMAT_1080p_6000_A,      1920,   1080,   8,  RGBA, 60,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_8_RGBA_60p
+
+    {NTV2_FORMAT_1080p_2398,        1920,   1080,   10, YUV,  24000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_1080_10_2398p
+    {NTV2_FORMAT_1080p_2400,        1920,   1080,   10, YUV,  24,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_10_24p
+    {NTV2_FORMAT_1080p_2500,        1920,   1080,   10, YUV,  25,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_10_25p
+    {NTV2_FORMAT_1080p_2997,        1920,   1080,   10, YUV,  30000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_1080_10_2997p
+    {NTV2_FORMAT_1080p_3000,        1920,   1080,   10, YUV,  30,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_10_30p
+    {NTV2_FORMAT_1080i_5000,        1920,   1080,   10, YUV,  25,       1,    true,   true,    HD},    // GST_AJA_MODE_RAW_1080_10_50i
+    {NTV2_FORMAT_1080p_5000_A,      1920,   1080,   10, YUV,  50,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_10_50p
+    {NTV2_FORMAT_1080i_5994,        1920,   1080,   10, YUV,  30000,    1001, true,   true,    HD},    // GST_AJA_MODE_RAW_1080_10_5994i
+    {NTV2_FORMAT_1080p_5994_A,      1920,   1080,   10, YUV,  60000,    1001, false,  true,    HD},    // GST_AJA_MODE_RAW_1080_10_5994p
+    {NTV2_FORMAT_1080i_6000,        1920,   1080,   10, YUV,  30,       1,    true,   true,    HD},    // GST_AJA_MODE_RAW_1080_10_60i
+    {NTV2_FORMAT_1080p_6000_A,      1920,   1080,   10, YUV,  60,       1,    false,  true,    HD},    // GST_AJA_MODE_RAW_1080_10_60p
+
+    {NTV2_FORMAT_3840x2160p_2398,   3840,   2160,   8,  YUV,  24000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_2398p
+    {NTV2_FORMAT_3840x2160p_2400,   3840,   2160,   8,  YUV,  24,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_24p
+    {NTV2_FORMAT_3840x2160p_2500,   3840,   2160,   8,  YUV,  25,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_25p
+    {NTV2_FORMAT_3840x2160p_2997,   3840,   2160,   8,  YUV,  30000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_2997p
+    {NTV2_FORMAT_3840x2160p_3000,   3840,   2160,   8,  YUV,  30,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_30p
+    {NTV2_FORMAT_3840x2160p_5000,   3840,   2160,   8,  YUV,  50,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_50p
+    {NTV2_FORMAT_3840x2160p_5994,   3840,   2160,   8,  YUV,  60000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_5994p
+    {NTV2_FORMAT_3840x2160p_6000,   3840,   2160,   8,  YUV,  60,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_60p
+
+    {NTV2_FORMAT_3840x2160p_2398,   3840,   2160,   8,  RGBA, 24000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_RGBA_2398p
+    {NTV2_FORMAT_3840x2160p_2400,   3840,   2160,   8,  RGBA, 24,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_RGBA_24p
+    {NTV2_FORMAT_3840x2160p_2500,   3840,   2160,   8,  RGBA, 25,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_RGBA_25p
+    {NTV2_FORMAT_3840x2160p_2997,   3840,   2160,   8,  RGBA, 30000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_RGBA_2997p
+    {NTV2_FORMAT_3840x2160p_3000,   3840,   2160,   8,  RGBA, 30,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_RGBA_30p
+    {NTV2_FORMAT_3840x2160p_5000,   3840,   2160,   8,  RGBA, 50,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_RGBA_50p
+    {NTV2_FORMAT_3840x2160p_5994,   3840,   2160,   8,  RGBA, 60000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_RGBA_5994p
+    {NTV2_FORMAT_3840x2160p_6000,   3840,   2160,   8,  RGBA, 60,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_8_RGBA_60p
+
+    {NTV2_FORMAT_3840x2160p_2398,   3840,   2160,   10, YUV,  24000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_10_2398p
+    {NTV2_FORMAT_3840x2160p_2400,   3840,   2160,   10, YUV,  24,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_10_24p
+    {NTV2_FORMAT_3840x2160p_2500,   3840,   2160,   10, YUV,  25,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_10_25p
+    {NTV2_FORMAT_3840x2160p_2997,   3840,   2160,   10, YUV,  30000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_10_2997p
+    {NTV2_FORMAT_3840x2160p_3000,   3840,   2160,   10, YUV,  30,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_10_30p
+    {NTV2_FORMAT_3840x2160p_5000,   3840,   2160,   10, YUV,  50,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_10_50p
+    {NTV2_FORMAT_3840x2160p_5994,   3840,   2160,   10, YUV,  60000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_10_5994p
+    {NTV2_FORMAT_3840x2160p_6000,   3840,   2160,   10, YUV,  60,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD_10_60p
+
+    {NTV2_FORMAT_4096x2160p_2398,   4096,   2160,   8,  YUV,  24000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_2398p
+    {NTV2_FORMAT_4096x2160p_2400,   4096,   2160,   8,  YUV,  24,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_24p
+    {NTV2_FORMAT_4096x2160p_2500,   4096,   2160,   8,  YUV,  25,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_25p
+    {NTV2_FORMAT_4096x2160p_2997,   4096,   2160,   8,  YUV,  30000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_2997p
+    {NTV2_FORMAT_4096x2160p_3000,   4096,   2160,   8,  YUV,  30,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_30p
+    {NTV2_FORMAT_4096x2160p_4795,   4096,   2160,   8,  YUV,  48000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_4795p
+    {NTV2_FORMAT_4096x2160p_4800,   4096,   2160,   8,  YUV,  48,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_48p
+    {NTV2_FORMAT_4096x2160p_5000,   4096,   2160,   8,  YUV,  50,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_50p
+    {NTV2_FORMAT_4096x2160p_5994,   4096,   2160,   8,  YUV,  60000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_5994p
+    {NTV2_FORMAT_4096x2160p_6000,   4096,   2160,   8,  YUV,  60,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_60p
+    {NTV2_FORMAT_4096x2160p_11988,  4096,   2160,   8,  YUV,  120000,   1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_11988p
+    {NTV2_FORMAT_4096x2160p_12000,  4096,   2160,   8,  YUV,  120,      1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_120p
+
+    {NTV2_FORMAT_4096x2160p_2398,   4096,   2160,   8,  RGBA, 24000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_RGBA_2398p
+    {NTV2_FORMAT_4096x2160p_2400,   4096,   2160,   8,  RGBA, 24,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_RGBA_24p
+    {NTV2_FORMAT_4096x2160p_2500,   4096,   2160,   8,  RGBA, 25,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_RGBA_25p
+    {NTV2_FORMAT_4096x2160p_2997,   4096,   2160,   8,  RGBA, 30000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_RGBA_2997p
+    {NTV2_FORMAT_4096x2160p_3000,   4096,   2160,   8,  RGBA, 30,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_RGBA_30p
+    {NTV2_FORMAT_4096x2160p_4795,   4096,   2160,   8,  RGBA, 48000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_RGBA_4795p
+    {NTV2_FORMAT_4096x2160p_4800,   4096,   2160,   8,  RGBA, 48,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_RGBA_48p
+    {NTV2_FORMAT_4096x2160p_5000,   4096,   2160,   8,  RGBA, 50,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_RGBA_50p
+    {NTV2_FORMAT_4096x2160p_5994,   4096,   2160,   8,  RGBA, 60000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_RGBA_5994p
+    {NTV2_FORMAT_4096x2160p_6000,   4096,   2160,   8,  RGBA, 60,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_RGBA_60p
+    {NTV2_FORMAT_4096x2160p_11988,  4096,   2160,   8,  RGBA, 120000,   1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_RGBA_11988p
+    {NTV2_FORMAT_4096x2160p_12000,  4096,   2160,   8,  RGBA, 120,      1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_8_RGBA_120p
+
+    {NTV2_FORMAT_4096x2160p_2398,   4096,   2160,   10, YUV,  24000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_2398p
+    {NTV2_FORMAT_4096x2160p_2400,   4096,   2160,   10, YUV,  24,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_24p
+    {NTV2_FORMAT_4096x2160p_2500,   4096,   2160,   10, YUV,  25,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_25p
+    {NTV2_FORMAT_4096x2160p_2997,   4096,   2160,   10, YUV,  30000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_2997p
+    {NTV2_FORMAT_4096x2160p_3000,   4096,   2160,   10, YUV,  30,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_30p
+    {NTV2_FORMAT_4096x2160p_4795,   4096,   2160,   10, YUV,  48000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_4795p
+    {NTV2_FORMAT_4096x2160p_4800,   4096,   2160,   10, YUV,  48,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_48p
+    {NTV2_FORMAT_4096x2160p_5000,   4096,   2160,   10, YUV,  50,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_50p
+    {NTV2_FORMAT_4096x2160p_5994,   4096,   2160,   10, YUV,  60000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_5994p
+    {NTV2_FORMAT_4096x2160p_6000,   4096,   2160,   10, YUV,  60,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_60p
+    {NTV2_FORMAT_4096x2160p_11988,  4096,   2160,   10, YUV,  120000,   1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_11988p
+    {NTV2_FORMAT_4096x2160p_12000,  4096,   2160,   10, YUV,  120,      1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_4K_10_120p
+
+    {NTV2_FORMAT_4x3840x2160p_2398, 7680,   4320,   8,  YUV,  24000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_8_2398p
+    {NTV2_FORMAT_4x3840x2160p_2400, 7680,   4320,   8,  YUV,  24,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_8_24p
+    {NTV2_FORMAT_4x3840x2160p_2500, 7680,   4320,   8,  YUV,  25,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_8_25p
+    {NTV2_FORMAT_4x3840x2160p_2997, 7680,   4320,   8,  YUV,  30000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_8_2997p
+    {NTV2_FORMAT_4x3840x2160p_3000, 7680,   4320,   8,  YUV,  30,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_8_30p
+    {NTV2_FORMAT_4x3840x2160p_5000, 7680,   4320,   8,  YUV,  50,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_8_50p
+    {NTV2_FORMAT_4x3840x2160p_5994, 7680,   4320,   8,  YUV,  60000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_8_5994p
+    {NTV2_FORMAT_4x3840x2160p_6000, 7680,   4320,   8,  YUV,  60,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_8_60p
+
+    {NTV2_FORMAT_4x3840x2160p_2398, 7680,   4320,   10, YUV,  24000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_10_2398p
+    {NTV2_FORMAT_4x3840x2160p_2400, 7680,   4320,   10, YUV,  24,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_10_24p
+    {NTV2_FORMAT_4x3840x2160p_2500, 7680,   4320,   10, YUV,  25,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_10_25p
+    {NTV2_FORMAT_4x3840x2160p_2997, 7680,   4320,   10, YUV,  30000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_10_2997p
+    {NTV2_FORMAT_4x3840x2160p_3000, 7680,   4320,   10, YUV,  30,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_10_30p
+    {NTV2_FORMAT_4x3840x2160p_5000, 7680,   4320,   10, YUV,  50,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_10_50p
+    {NTV2_FORMAT_4x3840x2160p_5994, 7680,   4320,   10, YUV,  60000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_10_5994p
+    {NTV2_FORMAT_4x3840x2160p_6000, 7680,   4320,   10, YUV,  60,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_UHD2_10_60p
+
+    {NTV2_FORMAT_4x4096x2160p_2398, 8192,   4320,   8,  YUV,  24000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_8_2398p
+    {NTV2_FORMAT_4x4096x2160p_2400, 8192,   4320,   8,  YUV,  24,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_8_24p
+    {NTV2_FORMAT_4x4096x2160p_2500, 8192,   4320,   8,  YUV,  25,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_8_25p
+    {NTV2_FORMAT_4x4096x2160p_2997, 8192,   4320,   8,  YUV,  30000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_8_2997p
+    {NTV2_FORMAT_4x4096x2160p_3000, 8192,   4320,   8,  YUV,  30,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_8_30p
+    {NTV2_FORMAT_4x4096x2160p_4795, 8192,   4320,   8,  YUV,  48000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_8_4795p
+    {NTV2_FORMAT_4x4096x2160p_4800, 8192,   4320,   8,  YUV,  48,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_8_48p
+    {NTV2_FORMAT_4x4096x2160p_5000, 8192,   4320,   8,  YUV,  50,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_8_50p
+    {NTV2_FORMAT_4x4096x2160p_5994, 8192,   4320,   8,  YUV,  60000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_8_5994p
+    {NTV2_FORMAT_4x4096x2160p_6000, 8192,   4320,   8,  YUV,  60,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_8_60p
+
+    {NTV2_FORMAT_4x4096x2160p_2398, 8192,   4320,   10, YUV,  24000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_10_2398p
+    {NTV2_FORMAT_4x4096x2160p_2400, 8192,   4320,   10, YUV,  24,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_10_24p
+    {NTV2_FORMAT_4x4096x2160p_2500, 8192,   4320,   10, YUV,  25,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_10_25p
+    {NTV2_FORMAT_4x4096x2160p_2997, 8192,   4320,   10, YUV,  30000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_10_2997p
+    {NTV2_FORMAT_4x4096x2160p_3000, 8192,   4320,   10, YUV,  30,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_10_30p
+    {NTV2_FORMAT_4x4096x2160p_4795, 8192,   4320,   10, YUV,  48000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_10_4795p
+    {NTV2_FORMAT_4x4096x2160p_4800, 8192,   4320,   10, YUV,  48,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_10_48p
+    {NTV2_FORMAT_4x4096x2160p_5000, 8192,   4320,   10, YUV,  50,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_10_50p
+    {NTV2_FORMAT_4x4096x2160p_5994, 8192,   4320,   10, YUV,  60000,    1001, false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_10_5994p
+    {NTV2_FORMAT_4x4096x2160p_6000, 8192,   4320,   10, YUV,  60,       1,    false,  true,    UHD},   // GST_AJA_MODE_RAW_8K_10_60p
 
 };
 
@@ -236,135 +282,178 @@ gst_aja_mode_get_type_raw (void)
     static gsize id = 0;
     static const GEnumValue modes[GST_AJA_MODE_RAW_END + 1] =
     {
-        {GST_AJA_MODE_RAW_NTSC_8_2398i,     "ntsc-2398",             "NTSC 8Bit 23.98i     "},
-        {GST_AJA_MODE_RAW_NTSC_8_24i,     "ntsc-24",             "NTSC 8Bit 24i     "},
-        {GST_AJA_MODE_RAW_NTSC_8_5994i,     "ntsc",             "NTSC 8Bit 59.94i     "},
-        {GST_AJA_MODE_RAW_NTSC_10_2398i,    "ntsc-2398-10",          "NTSC 10Bit 23.98i    "},
-        {GST_AJA_MODE_RAW_NTSC_10_24i,    "ntsc-24-10",          "NTSC 10Bit 24i    "},
-        {GST_AJA_MODE_RAW_NTSC_10_5994i,    "ntsc-10",          "NTSC 10Bit 59.94i    "},
-        
-        {GST_AJA_MODE_RAW_PAL_8_50i,        "pal",              "PAL 8Bit 50i         "},
-        {GST_AJA_MODE_RAW_PAL_10_50i,       "pal-10",           "PAL 10Bit 50i        "},
-        
-        {GST_AJA_MODE_RAW_720_8_2398p,        "720p2398",           "HD720 8Bit 23.98p       "},
-        {GST_AJA_MODE_RAW_720_8_25p,        "720p25",           "HD720 8Bit 25p       "},
-        {GST_AJA_MODE_RAW_720_8_50p,        "720p50",           "HD720 8Bit 50p       "},
-        {GST_AJA_MODE_RAW_720_8_5994p,      "720p5994",        "HD720 8Bit 59.94p    "},
-        {GST_AJA_MODE_RAW_720_8_60p,        "720p60",           "HD720 8Bit 60p       "},
-        {GST_AJA_MODE_RAW_720_10_2398p,       "720p2398-10",        "HD720 10Bit 23.98p      "},
-        {GST_AJA_MODE_RAW_720_10_25p,       "720p25-10",        "HD720 10Bit 25p      "},
-        {GST_AJA_MODE_RAW_720_10_50p,       "720p50-10",        "HD720 10Bit 50p      "},
-        {GST_AJA_MODE_RAW_720_10_5994p,     "720p5994-10",     "HD720 10Bit 59.94p   "},
-        {GST_AJA_MODE_RAW_720_10_60p,       "720p60-10",        "HD720 10Bit 60p      "},
-        
-        {GST_AJA_MODE_RAW_1080_8_2398p,       "1080p2398",          "HD1080 8Bit 23.98p     "},
-        {GST_AJA_MODE_RAW_1080_8_24p,       "1080p24",          "HD1080 8Bit 24p     "},
-        {GST_AJA_MODE_RAW_1080_8_25p,       "1080p25",          "HD1080 8Bit 25p     "},
-        {GST_AJA_MODE_RAW_1080_8_2997p,       "1080p2997",          "HD1080 8Bit 29.97p     "},
-        {GST_AJA_MODE_RAW_1080_8_30p,       "1080p30",          "HD1080 8Bit 30p     "},
-        {GST_AJA_MODE_RAW_1080_8_50i,       "1080i50",          "HD1080 8Bit 50i      "},
-        {GST_AJA_MODE_RAW_1080_8_50p,       "1080p50",          "HD1080 8Bit 50p      "},
-        {GST_AJA_MODE_RAW_1080_8_5994i,     "1080i5994",       "HD1080 8Bit 59.94i   "},
-        {GST_AJA_MODE_RAW_1080_8_5994p,     "1080p5994",       "HD1080 8Bit 59.94p   "},
-        {GST_AJA_MODE_RAW_1080_8_60i,       "1080i60",          "HD1080 8Bit 60i      "},
-        {GST_AJA_MODE_RAW_1080_8_60p,       "1080p60",          "HD1080 8Bit 60p      "},
-        
-        {GST_AJA_MODE_RAW_1080_10_2398p,      "1080p2398-10",       "HD1080 10Bit 23.98p     "},
-        {GST_AJA_MODE_RAW_1080_10_24p,      "1080p24-10",       "HD1080 10Bit 24p     "},
-        {GST_AJA_MODE_RAW_1080_10_25p,      "1080p25-10",       "HD1080 10Bit 25p     "},
-        {GST_AJA_MODE_RAW_1080_10_2997p,      "1080p2997-10",       "HD1080 10Bit 29.97p     "},
-        {GST_AJA_MODE_RAW_1080_10_30p,      "1080p30-10",       "HD1080 10Bit 30p     "},
-        {GST_AJA_MODE_RAW_1080_10_50i,      "1080i50-10",       "HD1080 10Bit 50i     "},
-        {GST_AJA_MODE_RAW_1080_10_50p,      "1080p50-10",       "HD1080 10Bit 50p     "},
-        {GST_AJA_MODE_RAW_1080_10_5994i,    "1080i5994-10",    "HD1080 10Bit 59.94i  "},
-        {GST_AJA_MODE_RAW_1080_10_5994p,    "1080p5994-10",    "HD1080 10Bit 59.94p  "},
-        {GST_AJA_MODE_RAW_1080_10_60i,      "1080i60-10",       "HD1080 10Bit 60i     "},
-        {GST_AJA_MODE_RAW_1080_10_60p,      "1080p60-10",       "HD1080 10Bit 60p     "},
-        
-        {GST_AJA_MODE_RAW_UHD_8_2398p,        "UHDp2398",           "UHD3840 8Bit 23.98p     "},
-        {GST_AJA_MODE_RAW_UHD_8_24p,        "UHDp24",           "UHD3840 8Bit 24p     "},
-        {GST_AJA_MODE_RAW_UHD_8_25p,        "UHDp25",           "UHD3840 8Bit 25p     "},
-        {GST_AJA_MODE_RAW_UHD_8_2997p,        "UHDp2997",           "UHD3840 8Bit 29.97p     "},
-        {GST_AJA_MODE_RAW_UHD_8_30p,        "UHDp30",           "UHD3840 8Bit 30p     "},
-        {GST_AJA_MODE_RAW_UHD_8_50p,        "UHDp50",           "UHD3840 8Bit 50p     "},
-        {GST_AJA_MODE_RAW_UHD_8_5994p,      "UHDp5994",        "UHD3840 8Bit 59.94p  "},
-        {GST_AJA_MODE_RAW_UHD_8_60p,        "UHDp60",           "UHD3840 8Bit 60p     "},
-        
-        {GST_AJA_MODE_RAW_UHD_10_2398p,       "UHDp2398-10",        "UHD3840 10Bit 23.98p    "},
-        {GST_AJA_MODE_RAW_UHD_10_24p,       "UHDp24-10",        "UHD3840 10Bit 24p    "},
-        {GST_AJA_MODE_RAW_UHD_10_25p,       "UHDp25-10",        "UHD3840 10Bit 25p    "},
-        {GST_AJA_MODE_RAW_UHD_10_2997p,       "UHDp2997-10",        "UHD3840 10Bit 29.97p    "},
-        {GST_AJA_MODE_RAW_UHD_10_30p,       "UHDp30-10",        "UHD3840 10Bit 30p    "},
-        {GST_AJA_MODE_RAW_UHD_10_50p,       "UHDp50-10",        "UHD3840 10Bit 50p    "},
-        {GST_AJA_MODE_RAW_UHD_10_5994p,     "UHDp5994-10",     "UHD3840 10Bit 59.94p "},
-        {GST_AJA_MODE_RAW_UHD_10_60p,       "UHDp60-10",        "UHD3840 10Bit 60p    "},
-        
-        {GST_AJA_MODE_RAW_4K_8_2398p,         "4Kp2398",            "4K4096 8Bit 23.98p      "},
-        {GST_AJA_MODE_RAW_4K_8_24p,         "4Kp24",            "4K4096 8Bit 24p      "},
-        {GST_AJA_MODE_RAW_4K_8_25p,         "4Kp25",            "4K4096 8Bit 25p      "},
-        {GST_AJA_MODE_RAW_4K_8_2997p,         "4Kp2997",            "4K4096 8Bit 29.97p      "},
-        {GST_AJA_MODE_RAW_4K_8_30p,         "4Kp30",            "4K4096 8Bit 30p      "},
-        {GST_AJA_MODE_RAW_4K_8_4795p,         "4Kp4795",            "4K4096 8Bit 47.95p      "},
-        {GST_AJA_MODE_RAW_4K_8_48p,         "4Kp48",            "4K4096 8Bit 48p      "},
-        {GST_AJA_MODE_RAW_4K_8_50p,         "4Kp50",            "4K4096 8Bit 50p      "},
-        {GST_AJA_MODE_RAW_4K_8_5994p,       "4Kp5994",         "4K4096 8Bit 59.94p   "},
-        {GST_AJA_MODE_RAW_4K_8_60p,         "4Kp60",            "4K4096 8Bit 60p      "},
-        {GST_AJA_MODE_RAW_4K_8_11988p,         "4Kp11988",            "4K4096 8Bit 119.88p      "},
-        {GST_AJA_MODE_RAW_4K_8_120p,         "4Kp120",            "4K4096 8Bit 120p      "},
-        
-        {GST_AJA_MODE_RAW_4K_10_2398p,        "4Kp2398-10",         "4K4096 10Bit 23.98p     "},
-        {GST_AJA_MODE_RAW_4K_10_24p,        "4Kp24-10",         "4K4096 10Bit 24p     "},
-        {GST_AJA_MODE_RAW_4K_10_25p,        "4Kp25-10",         "4K4096 10Bit 25p     "},
-        {GST_AJA_MODE_RAW_4K_10_2997p,        "4Kp2997-10",         "4K4096 10Bit 29.97p     "},
-        {GST_AJA_MODE_RAW_4K_10_30p,        "4Kp30-10",         "4K4096 10Bit 30p     "},
-        {GST_AJA_MODE_RAW_4K_10_4795p,        "4Kp4795-10",         "4K4096 10Bit 47.95p     "},
-        {GST_AJA_MODE_RAW_4K_10_48p,        "4Kp48-10",         "4K4096 10Bit 48p     "},
-        {GST_AJA_MODE_RAW_4K_10_50p,        "4Kp50-10",         "4K4096 10Bit 50p     "},
-        {GST_AJA_MODE_RAW_4K_10_5994p,      "4Kp5994-10",      "4K4096 10Bit 59.94p  "},
-        {GST_AJA_MODE_RAW_4K_10_60p,        "4Kp60-10",         "4K4096 10Bit 60p     "},
-        {GST_AJA_MODE_RAW_4K_10_11988p,        "4Kp11988-10",         "4K4096 10Bit 119.88p     "},
-        {GST_AJA_MODE_RAW_4K_10_120p,        "4Kp1200-10",         "4K4096 10Bit 120p     "},
-        
-        {GST_AJA_MODE_RAW_UHD2_8_2398p,        "UHD2p2398",           "UHD-2 7680 8Bit 23.98p     "},
-        {GST_AJA_MODE_RAW_UHD2_8_24p,        "UHD2p24",           "UHD-2 7680 8Bit 24p     "},
-        {GST_AJA_MODE_RAW_UHD2_8_25p,        "UHD2p25",           "UHD-2 7680 8Bit 25p     "},
-        {GST_AJA_MODE_RAW_UHD2_8_2997p,        "UHD2p2997",           "UHD-2 7680 8Bit 29.97p     "},
-        {GST_AJA_MODE_RAW_UHD2_8_30p,        "UHD2p30",           "UHD-2 7680 8Bit 30p     "},
-        {GST_AJA_MODE_RAW_UHD2_8_50p,        "UHD2p50",           "UHD-2 7680 8Bit 50p     "},
-        {GST_AJA_MODE_RAW_UHD2_8_5994p,      "UHD2p5994",        "UHD-2 7680 8Bit 59.94p  "},
-        {GST_AJA_MODE_RAW_UHD2_8_60p,        "UHD2p60",           "UHD-2 7680 8Bit 60p     "},
-        
-        {GST_AJA_MODE_RAW_UHD2_10_2398p,       "UHD2p2398-10",        "UHD-2 7680 10Bit 23.98p    "},
-        {GST_AJA_MODE_RAW_UHD2_10_24p,       "UHD2p24-10",        "UHD-2 7680 10Bit 24p    "},
-        {GST_AJA_MODE_RAW_UHD2_10_25p,       "UHD2p25-10",        "UHD-2 7680 10Bit 25p    "},
-        {GST_AJA_MODE_RAW_UHD2_10_2997p,       "UHD2p2997-10",        "UHD-2 7680 10Bit 29.97p    "},
-        {GST_AJA_MODE_RAW_UHD2_10_30p,       "UHD2p30-10",        "UHD-2 7680 10Bit 30p    "},
-        {GST_AJA_MODE_RAW_UHD2_10_50p,       "UHD2p50-10",        "UHD-2 7680 10Bit 50p    "},
-        {GST_AJA_MODE_RAW_UHD2_10_5994p,     "UHD2p5994-10",     "UHD-2 7680 10Bit 59.94p "},
-        {GST_AJA_MODE_RAW_UHD2_10_60p,       "UHD2p60-10",        "UHD-2 7680 10Bit 60p    "},
-        
-        {GST_AJA_MODE_RAW_8K_8_2398p,         "8Kp2398",            "8K8192 8Bit 23.98p      "},
-        {GST_AJA_MODE_RAW_8K_8_24p,         "8Kp24",            "8K8192 8Bit 24p      "},
-        {GST_AJA_MODE_RAW_8K_8_25p,         "8Kp25",            "8K8192 8Bit 25p      "},
-        {GST_AJA_MODE_RAW_8K_8_2997p,         "8Kp2997",            "8K8192 8Bit 29.97p      "},
-        {GST_AJA_MODE_RAW_8K_8_30p,         "8Kp30",            "8K8192 8Bit 30p      "},
-        {GST_AJA_MODE_RAW_8K_8_4795p,         "8Kp4795",            "8K8192 8Bit 47.95p      "},
-        {GST_AJA_MODE_RAW_8K_8_48p,         "8Kp48",            "8K8192 8Bit 48p      "},
-        {GST_AJA_MODE_RAW_8K_8_50p,         "8Kp50",            "8K8192 8Bit 50p      "},
-        {GST_AJA_MODE_RAW_8K_8_5994p,       "8Kp5994",         "8K8192 8Bit 59.94p   "},
-        {GST_AJA_MODE_RAW_8K_8_60p,         "8Kp60",            "8K8192 8Bit 60p      "},
-        
-        {GST_AJA_MODE_RAW_8K_10_2398p,        "8Kp2398-10",         "8K8192 10Bit 23.98p     "},
-        {GST_AJA_MODE_RAW_8K_10_24p,        "8Kp24-10",         "8K8192 10Bit 24p     "},
-        {GST_AJA_MODE_RAW_8K_10_25p,        "8Kp25-10",         "8K8192 10Bit 25p     "},
-        {GST_AJA_MODE_RAW_8K_10_2997p,        "8Kp2997-10",         "8K8192 10Bit 29.97p     "},
-        {GST_AJA_MODE_RAW_8K_10_30p,        "8Kp30-10",         "8K8192 10Bit 30p     "},
-        {GST_AJA_MODE_RAW_8K_10_4795p,        "8Kp4795-10",         "8K8192 10Bit 47.95p     "},
-        {GST_AJA_MODE_RAW_8K_10_48p,        "8Kp48-10",         "8K8192 10Bit 48p     "},
-        {GST_AJA_MODE_RAW_8K_10_50p,        "8Kp50-10",         "8K8192 10Bit 50p     "},
-        {GST_AJA_MODE_RAW_8K_10_5994p,      "8Kp5994-10",      "8K8192 10Bit 59.94p  "},
-        {GST_AJA_MODE_RAW_8K_10_60p,        "8Kp60-10",         "8K8192 10Bit 60p     "},
-        {0,                                 NULL,               NULL}
+        {GST_AJA_MODE_RAW_NTSC_8_2398i,      "ntsc-2398",       "NTSC 8Bit 23.98i             "},
+        {GST_AJA_MODE_RAW_NTSC_8_24i,        "ntsc-24",         "NTSC 8Bit 24i                "},
+        {GST_AJA_MODE_RAW_NTSC_8_5994i,      "ntsc",            "NTSC 8Bit 59.94i             "},
+        {GST_AJA_MODE_RAW_NTSC_8_RGBA_2398i, "ntsc-2398-rgba",  "NTSC 8Bit RGBA 23.98i        "},
+        {GST_AJA_MODE_RAW_NTSC_8_RGBA_24i,   "ntsc-24-rgba",    "NTSC 8Bit RGBA 24i           "},
+        {GST_AJA_MODE_RAW_NTSC_8_RGBA_5994i, "ntsc-rgba",       "NTSC 8Bit RGBA 59.94i        "},
+        {GST_AJA_MODE_RAW_NTSC_10_2398i,     "ntsc-2398-10",    "NTSC 10Bit 23.98i            "},
+        {GST_AJA_MODE_RAW_NTSC_10_24i,       "ntsc-24-10",      "NTSC 10Bit 24i               "},
+        {GST_AJA_MODE_RAW_NTSC_10_5994i,     "ntsc-10",         "NTSC 10Bit 59.94i            "},
+
+        {GST_AJA_MODE_RAW_PAL_8_50i,         "pal",             "PAL 8Bit 50i                 "},
+        {GST_AJA_MODE_RAW_PAL_8_RGBA_50i,    "pal-rgba",        "PAL 8Bit RGBA 50i           "},
+        {GST_AJA_MODE_RAW_PAL_10_50i,        "pal-10",          "PAL 10Bit 50i               "},
+
+        {GST_AJA_MODE_RAW_720_8_2398p,       "720p2398",        "HD720 8Bit 23.98p           "},
+        {GST_AJA_MODE_RAW_720_8_25p,         "720p25",          "HD720 8Bit 25p              "},
+        {GST_AJA_MODE_RAW_720_8_50p,         "720p50",          "HD720 8Bit 50p              "},
+        {GST_AJA_MODE_RAW_720_8_5994p,       "720p5994",        "HD720 8Bit 59.94p           "},
+        {GST_AJA_MODE_RAW_720_8_60p,         "720p60",          "HD720 8Bit 60p              "},
+        {GST_AJA_MODE_RAW_720_8_RGBA_2398p,  "720p2398-rgba",   "HD720 8Bit RGBA 23.98p      "},
+        {GST_AJA_MODE_RAW_720_8_RGBA_25p,    "720p25-rgba",     "HD720 8Bit RGBA 25p         "},
+        {GST_AJA_MODE_RAW_720_8_RGBA_50p,    "720p50-rgba",     "HD720 8Bit RGBA 50p         "},
+        {GST_AJA_MODE_RAW_720_8_RGBA_5994p,  "720p5994-rgba",   "HD720 8Bit RGBA 59.94p      "},
+        {GST_AJA_MODE_RAW_720_8_RGBA_60p,    "720p60-rgba",     "HD720 8Bit RGBA 60p         "},
+        {GST_AJA_MODE_RAW_720_10_2398p,      "720p2398-10",     "HD720 10Bit 23.98p          "},
+        {GST_AJA_MODE_RAW_720_10_25p,        "720p25-10",       "HD720 10Bit 25p             "},
+        {GST_AJA_MODE_RAW_720_10_50p,        "720p50-10",       "HD720 10Bit 50p             "},
+        {GST_AJA_MODE_RAW_720_10_5994p,      "720p5994-10",     "HD720 10Bit 59.94p          "},
+        {GST_AJA_MODE_RAW_720_10_60p,        "720p60-10",       "HD720 10Bit 60p             "},
+
+        {GST_AJA_MODE_RAW_1080_8_2398p,      "1080p2398",       "HD1080 8Bit 23.98p          "},
+        {GST_AJA_MODE_RAW_1080_8_24p,        "1080p24",         "HD1080 8Bit 24p             "},
+        {GST_AJA_MODE_RAW_1080_8_25p,        "1080p25",         "HD1080 8Bit 25p             "},
+        {GST_AJA_MODE_RAW_1080_8_2997p,      "1080p2997",       "HD1080 8Bit 29.97p          "},
+        {GST_AJA_MODE_RAW_1080_8_30p,        "1080p30",         "HD1080 8Bit 30p             "},
+        {GST_AJA_MODE_RAW_1080_8_50i,        "1080i50",         "HD1080 8Bit 50i             "},
+        {GST_AJA_MODE_RAW_1080_8_50p,        "1080p50",         "HD1080 8Bit 50p             "},
+        {GST_AJA_MODE_RAW_1080_8_5994i,      "1080i5994",       "HD1080 8Bit 59.94i          "},
+        {GST_AJA_MODE_RAW_1080_8_5994p,      "1080p5994",       "HD1080 8Bit 59.94p          "},
+        {GST_AJA_MODE_RAW_1080_8_60i,        "1080i60",         "HD1080 8Bit 60i             "},
+        {GST_AJA_MODE_RAW_1080_8_60p,        "1080p60",         "HD1080 8Bit 60p             "},
+
+        {GST_AJA_MODE_RAW_1080_8_RGBA_2398p, "1080p2398-rgba",  "HD1080 8Bit RGBA 23.98p     "},
+        {GST_AJA_MODE_RAW_1080_8_RGBA_24p,   "1080p24-rgba",    "HD1080 8Bit RGBA 24p        "},
+        {GST_AJA_MODE_RAW_1080_8_RGBA_25p,   "1080p25-rgba",    "HD1080 8Bit RGBA 25p        "},
+        {GST_AJA_MODE_RAW_1080_8_RGBA_2997p, "1080p2997-rgba",  "HD1080 8Bit RGBA 29.97p     "},
+        {GST_AJA_MODE_RAW_1080_8_RGBA_30p,   "1080p30-rgba",    "HD1080 8Bit RGBA 30p        "},
+        {GST_AJA_MODE_RAW_1080_8_RGBA_50i,   "1080i50-rgba",    "HD1080 8Bit RGBA 50i        "},
+        {GST_AJA_MODE_RAW_1080_8_RGBA_50p,   "1080p50-rgba",    "HD1080 8Bit RGBA 50p        "},
+        {GST_AJA_MODE_RAW_1080_8_RGBA_5994i, "1080i5994-rgba",  "HD1080 8Bit RGBA 59.94i     "},
+        {GST_AJA_MODE_RAW_1080_8_RGBA_5994p, "1080p5994-rgba",  "HD1080 8Bit RGBA 59.94p     "},
+        {GST_AJA_MODE_RAW_1080_8_RGBA_60i,   "1080i60-rgba",    "HD1080 8Bit RGBA 60i        "},
+        {GST_AJA_MODE_RAW_1080_8_RGBA_60p,   "1080p60-rgba",    "HD1080 8Bit RGBA 60p        "},
+
+        {GST_AJA_MODE_RAW_1080_10_2398p,     "1080p2398-10",    "HD1080 10Bit 23.98p         "},
+        {GST_AJA_MODE_RAW_1080_10_24p,       "1080p24-10",      "HD1080 10Bit 24p            "},
+        {GST_AJA_MODE_RAW_1080_10_25p,       "1080p25-10",      "HD1080 10Bit 25p            "},
+        {GST_AJA_MODE_RAW_1080_10_2997p,     "1080p2997-10",    "HD1080 10Bit 29.97p         "},
+        {GST_AJA_MODE_RAW_1080_10_30p,       "1080p30-10",      "HD1080 10Bit 30p            "},
+        {GST_AJA_MODE_RAW_1080_10_50i,       "1080i50-10",      "HD1080 10Bit 50i            "},
+        {GST_AJA_MODE_RAW_1080_10_50p,       "1080p50-10",      "HD1080 10Bit 50p            "},
+        {GST_AJA_MODE_RAW_1080_10_5994i,     "1080i5994-10",    "HD1080 10Bit 59.94i         "},
+        {GST_AJA_MODE_RAW_1080_10_5994p,     "1080p5994-10",    "HD1080 10Bit 59.94p         "},
+        {GST_AJA_MODE_RAW_1080_10_60i,       "1080i60-10",      "HD1080 10Bit 60i            "},
+        {GST_AJA_MODE_RAW_1080_10_60p,       "1080p60-10",      "HD1080 10Bit 60p            "},
+
+        {GST_AJA_MODE_RAW_UHD_8_2398p,       "UHDp2398",        "UHD3840 8Bit 23.98p         "},
+        {GST_AJA_MODE_RAW_UHD_8_24p,         "UHDp24",          "UHD3840 8Bit 24p            "},
+        {GST_AJA_MODE_RAW_UHD_8_25p,         "UHDp25",          "UHD3840 8Bit 25p            "},
+        {GST_AJA_MODE_RAW_UHD_8_2997p,       "UHDp2997",        "UHD3840 8Bit 29.97p         "},
+        {GST_AJA_MODE_RAW_UHD_8_30p,         "UHDp30",          "UHD3840 8Bit 30p            "},
+        {GST_AJA_MODE_RAW_UHD_8_50p,         "UHDp50",          "UHD3840 8Bit 50p            "},
+        {GST_AJA_MODE_RAW_UHD_8_5994p,       "UHDp5994",        "UHD3840 8Bit 59.94p         "},
+        {GST_AJA_MODE_RAW_UHD_8_60p,         "UHDp60",          "UHD3840 8Bit 60p            "},
+
+        {GST_AJA_MODE_RAW_UHD_8_RGBA_2398p,  "UHDp2398-rgba",   "UHD3840 8Bit RGBA 23.98p    "},
+        {GST_AJA_MODE_RAW_UHD_8_RGBA_24p,    "UHDp24-rgba",     "UHD3840 8Bit RGBA 24p       "},
+        {GST_AJA_MODE_RAW_UHD_8_RGBA_25p,    "UHDp25-rgba",     "UHD3840 8Bit RGBA 25p       "},
+        {GST_AJA_MODE_RAW_UHD_8_RGBA_2997p,  "UHDp2997-rgba",   "UHD3840 8Bit RGBA 29.97p    "},
+        {GST_AJA_MODE_RAW_UHD_8_RGBA_30p,    "UHDp30-rgba",     "UHD3840 8Bit RGBA 30p       "},
+        {GST_AJA_MODE_RAW_UHD_8_RGBA_50p,    "UHDp50-rgba",     "UHD3840 8Bit RGBA 50p       "},
+        {GST_AJA_MODE_RAW_UHD_8_RGBA_5994p,  "UHDp5994-rgba",   "UHD3840 8Bit RGBA 59.94p    "},
+        {GST_AJA_MODE_RAW_UHD_8_RGBA_60p,    "UHDp60-rgba",     "UHD3840 8Bit RGBA 60p       "},
+
+        {GST_AJA_MODE_RAW_UHD_10_2398p,      "UHDp2398-10",     "UHD3840 10Bit 23.98p        "},
+        {GST_AJA_MODE_RAW_UHD_10_24p,        "UHDp24-10",       "UHD3840 10Bit 24p           "},
+        {GST_AJA_MODE_RAW_UHD_10_25p,        "UHDp25-10",       "UHD3840 10Bit 25p           "},
+        {GST_AJA_MODE_RAW_UHD_10_2997p,      "UHDp2997-10",     "UHD3840 10Bit 29.97p        "},
+        {GST_AJA_MODE_RAW_UHD_10_30p,        "UHDp30-10",       "UHD3840 10Bit 30p           "},
+        {GST_AJA_MODE_RAW_UHD_10_50p,        "UHDp50-10",       "UHD3840 10Bit 50p           "},
+        {GST_AJA_MODE_RAW_UHD_10_5994p,      "UHDp5994-10",     "UHD3840 10Bit 59.94p        "},
+        {GST_AJA_MODE_RAW_UHD_10_60p,        "UHDp60-10",       "UHD3840 10Bit 60p           "},
+
+        {GST_AJA_MODE_RAW_4K_8_2398p,        "4Kp2398",         "4K4096 8Bit 23.98p          "},
+        {GST_AJA_MODE_RAW_4K_8_24p,          "4Kp24",           "4K4096 8Bit 24p             "},
+        {GST_AJA_MODE_RAW_4K_8_25p,          "4Kp25",           "4K4096 8Bit 25p             "},
+        {GST_AJA_MODE_RAW_4K_8_2997p,        "4Kp2997",         "4K4096 8Bit 29.97p          "},
+        {GST_AJA_MODE_RAW_4K_8_30p,          "4Kp30",           "4K4096 8Bit 30p             "},
+        {GST_AJA_MODE_RAW_4K_8_4795p,        "4Kp4795",         "4K4096 8Bit 47.95p          "},
+        {GST_AJA_MODE_RAW_4K_8_48p,          "4Kp48",           "4K4096 8Bit 48p             "},
+        {GST_AJA_MODE_RAW_4K_8_50p,          "4Kp50",           "4K4096 8Bit 50p             "},
+        {GST_AJA_MODE_RAW_4K_8_5994p,        "4Kp5994",         "4K4096 8Bit 59.94p          "},
+        {GST_AJA_MODE_RAW_4K_8_60p,          "4Kp60",           "4K4096 8Bit 60p             "},
+        {GST_AJA_MODE_RAW_4K_8_11988p,       "4Kp11988",        "4K4096 8Bit 119.88p         "},
+        {GST_AJA_MODE_RAW_4K_8_120p,         "4Kp120",          "4K4096 8Bit 120p            "},
+
+        {GST_AJA_MODE_RAW_4K_8_RGBA_2398p,   "4Kp2398-rgba",    "4K4096 8Bit RGBA 23.98p     "},
+        {GST_AJA_MODE_RAW_4K_8_RGBA_24p,     "4Kp24-rgba",      "4K4096 8Bit RGBA 24p        "},
+        {GST_AJA_MODE_RAW_4K_8_RGBA_25p,     "4Kp25-rgba",      "4K4096 8Bit RGBA 25p        "},
+        {GST_AJA_MODE_RAW_4K_8_RGBA_2997p,   "4Kp2997-rgba",    "4K4096 8Bit RGBA 29.97p     "},
+        {GST_AJA_MODE_RAW_4K_8_RGBA_30p,     "4Kp30-rgba",      "4K4096 8Bit RGBA 30p       "},
+        {GST_AJA_MODE_RAW_4K_8_RGBA_4795p,   "4Kp4795-rgba",    "4K4096 8Bit RGBA 47.95p    "},
+        {GST_AJA_MODE_RAW_4K_8_RGBA_48p,     "4Kp48-rgba",      "4K4096 8Bit RGBA 48p       "},
+        {GST_AJA_MODE_RAW_4K_8_RGBA_50p,     "4Kp50-rgba",      "4K4096 8Bit RGBA 50p       "},
+        {GST_AJA_MODE_RAW_4K_8_RGBA_5994p,   "4Kp5994-rgba",    "4K4096 8Bit RGBA 59.94p    "},
+        {GST_AJA_MODE_RAW_4K_8_RGBA_60p,     "4Kp60-rgba",      "4K4096 8Bit RGBA 60p       "},
+        {GST_AJA_MODE_RAW_4K_8_RGBA_11988p,  "4Kp11988-rgba",   "4K4096 8Bit RGBA 119.88p   "},
+        {GST_AJA_MODE_RAW_4K_8_RGBA_120p,    "4Kp120-rgba",     "4K4096 8Bit RGBA 120p      "},
+
+        {GST_AJA_MODE_RAW_4K_10_2398p,       "4Kp2398-10",      "4K4096 10Bit 23.98p        "},
+        {GST_AJA_MODE_RAW_4K_10_24p,         "4Kp24-10",        "4K4096 10Bit 24p           "},
+        {GST_AJA_MODE_RAW_4K_10_25p,         "4Kp25-10",        "4K4096 10Bit 25p           "},
+        {GST_AJA_MODE_RAW_4K_10_2997p,       "4Kp2997-10",      "4K4096 10Bit 29.97p        "},
+        {GST_AJA_MODE_RAW_4K_10_30p,         "4Kp30-10",        "4K4096 10Bit 30p           "},
+        {GST_AJA_MODE_RAW_4K_10_4795p,       "4Kp4795-10",      "4K4096 10Bit 47.95p        "},
+        {GST_AJA_MODE_RAW_4K_10_48p,         "4Kp48-10",        "4K4096 10Bit 48p           "},
+        {GST_AJA_MODE_RAW_4K_10_50p,         "4Kp50-10",        "4K4096 10Bit 50p           "},
+        {GST_AJA_MODE_RAW_4K_10_5994p,       "4Kp5994-10",      "4K4096 10Bit 59.94p        "},
+        {GST_AJA_MODE_RAW_4K_10_60p,         "4Kp60-10",        "4K4096 10Bit 60p           "},
+        {GST_AJA_MODE_RAW_4K_10_11988p,      "4Kp11988-10",     "4K4096 10Bit 119.88p       "},
+        {GST_AJA_MODE_RAW_4K_10_120p,        "4Kp1200-10",      "4K4096 10Bit 120p          "},
+
+        {GST_AJA_MODE_RAW_UHD2_8_2398p,      "UHD2p2398",       "UHD-2 7680 8Bit 23.98p     "},
+        {GST_AJA_MODE_RAW_UHD2_8_24p,        "UHD2p24",         "UHD-2 7680 8Bit 24p        "},
+        {GST_AJA_MODE_RAW_UHD2_8_25p,        "UHD2p25",         "UHD-2 7680 8Bit 25p        "},
+        {GST_AJA_MODE_RAW_UHD2_8_2997p,      "UHD2p2997",       "UHD-2 7680 8Bit 29.97p     "},
+        {GST_AJA_MODE_RAW_UHD2_8_30p,        "UHD2p30",         "UHD-2 7680 8Bit 30p        "},
+        {GST_AJA_MODE_RAW_UHD2_8_50p,        "UHD2p50",         "UHD-2 7680 8Bit 50p        "},
+        {GST_AJA_MODE_RAW_UHD2_8_5994p,      "UHD2p5994",       "UHD-2 7680 8Bit 59.94p     "},
+        {GST_AJA_MODE_RAW_UHD2_8_60p,        "UHD2p60",         "UHD-2 7680 8Bit 60p        "},
+
+        {GST_AJA_MODE_RAW_UHD2_10_2398p,     "UHD2p2398-10",    "UHD-2 7680 10Bit 23.98p    "},
+        {GST_AJA_MODE_RAW_UHD2_10_24p,       "UHD2p24-10",      "UHD-2 7680 10Bit 24p       "},
+        {GST_AJA_MODE_RAW_UHD2_10_25p,       "UHD2p25-10",      "UHD-2 7680 10Bit 25p       "},
+        {GST_AJA_MODE_RAW_UHD2_10_2997p,     "UHD2p2997-10",    "UHD-2 7680 10Bit 29.97p    "},
+        {GST_AJA_MODE_RAW_UHD2_10_30p,       "UHD2p30-10",      "UHD-2 7680 10Bit 30p       "},
+        {GST_AJA_MODE_RAW_UHD2_10_50p,       "UHD2p50-10",      "UHD-2 7680 10Bit 50p       "},
+        {GST_AJA_MODE_RAW_UHD2_10_5994p,     "UHD2p5994-10",    "UHD-2 7680 10Bit 59.94p    "},
+        {GST_AJA_MODE_RAW_UHD2_10_60p,       "UHD2p60-10",      "UHD-2 7680 10Bit 60p       "},
+
+        {GST_AJA_MODE_RAW_8K_8_2398p,        "8Kp2398",         "8K8192 8Bit 23.98p         "},
+        {GST_AJA_MODE_RAW_8K_8_24p,          "8Kp24",           "8K8192 8Bit 24p            "},
+        {GST_AJA_MODE_RAW_8K_8_25p,          "8Kp25",           "8K8192 8Bit 25p            "},
+        {GST_AJA_MODE_RAW_8K_8_2997p,        "8Kp2997",         "8K8192 8Bit 29.97p         "},
+        {GST_AJA_MODE_RAW_8K_8_30p,          "8Kp30",           "8K8192 8Bit 30p            "},
+        {GST_AJA_MODE_RAW_8K_8_4795p,        "8Kp4795",         "8K8192 8Bit 47.95p         "},
+        {GST_AJA_MODE_RAW_8K_8_48p,          "8Kp48",           "8K8192 8Bit 48p            "},
+        {GST_AJA_MODE_RAW_8K_8_50p,          "8Kp50",           "8K8192 8Bit 50p            "},
+        {GST_AJA_MODE_RAW_8K_8_5994p,        "8Kp5994",         "8K8192 8Bit 59.94p         "},
+        {GST_AJA_MODE_RAW_8K_8_60p,          "8Kp60",           "8K8192 8Bit 60p            "},
+
+        {GST_AJA_MODE_RAW_8K_10_2398p,       "8Kp2398-10",      "8K8192 10Bit 23.98p        "},
+        {GST_AJA_MODE_RAW_8K_10_24p,         "8Kp24-10",        "8K8192 10Bit 24p           "},
+        {GST_AJA_MODE_RAW_8K_10_25p,         "8Kp25-10",        "8K8192 10Bit 25p           "},
+        {GST_AJA_MODE_RAW_8K_10_2997p,       "8Kp2997-10",      "8K8192 10Bit 29.97p        "},
+        {GST_AJA_MODE_RAW_8K_10_30p,         "8Kp30-10",        "8K8192 10Bit 30p           "},
+        {GST_AJA_MODE_RAW_8K_10_4795p,       "8Kp4795-10",      "8K8192 10Bit 47.95p        "},
+        {GST_AJA_MODE_RAW_8K_10_48p,         "8Kp48-10",        "8K8192 10Bit 48p           "},
+        {GST_AJA_MODE_RAW_8K_10_50p,         "8Kp50-10",        "8K8192 10Bit 50p           "},
+        {GST_AJA_MODE_RAW_8K_10_5994p,       "8Kp5994-10",      "8K8192 10Bit 59.94p        "},
+        {GST_AJA_MODE_RAW_8K_10_60p,         "8Kp60-10",        "8K8192 10Bit 60p           "},
+        {0,                                  NULL,              NULL}
     };
     
     if (g_once_init_enter (&id))
@@ -392,8 +481,16 @@ gst_aja_mode_get_structure_raw (GstAjaModeRawEnum e)
   const GstAjaMode *mode = gst_aja_get_mode_raw (e);
   GstStructure *s;
 
+  const gchar *format;
+  if (mode->isRGBA)
+    format = "RGBA";
+  else if (mode->bitDepth == 8)
+    format = "UYVY";
+  else
+    format = "v210";
+
   s = gst_structure_new ("video/x-raw",
-      "format", G_TYPE_STRING, mode->bitDepth == 8 ? "UYVY" : "v210",
+      "format", G_TYPE_STRING, format,
       "width", G_TYPE_INT, mode->width,
       "height", G_TYPE_INT, mode->height,
       "framerate", GST_TYPE_FRACTION, mode->fps_n, mode->fps_d,

--- a/gst-plugin/aja/gstaja.h
+++ b/gst-plugin/aja/gstaja.h
@@ -31,6 +31,10 @@
 #include "ntv2enums.h"
 #include "ntv2m31enums.h"
 
+#if ENABLE_NVMM
+#include "gstnvdsbufferpool.h"
+#endif
+
 typedef enum
 {
     GST_AJA_MODE_RAW_NTSC_8_2398i,
@@ -275,7 +279,7 @@ struct _GstAjaMode
 
 const GstAjaMode * gst_aja_get_mode_raw (GstAjaModeRawEnum e);
 
-GstCaps * gst_aja_mode_get_caps_raw (GstAjaModeRawEnum e);
+GstCaps * gst_aja_mode_get_caps_raw (GstAjaModeRawEnum e, gboolean isNvmm);
 GstCaps * gst_aja_mode_get_template_caps_raw (void);
 
 typedef struct _GstAjaOutput GstAjaOutput;
@@ -417,5 +421,36 @@ struct _GstAjaAllocatorClass
 
 GType gst_aja_allocator_get_type (void);
 GstAllocator * gst_aja_allocator_new (CNTV2Card *device, gsize alloc_size, guint num_prealloc);
+
+
+#if ENABLE_NVMM
+
+#define GST_TYPE_AJA_NVMM_BUFFER_POOL \
+    (gst_aja_nvmm_buffer_pool_get_type())
+#define GST_IS_AJA_NVMM_BUFFER_POOL(obj) \
+    (G_TYPE_CHECK_INSTANCE_TYPE((obj), GST_TYPE_AJA_NVMM_BUFFER_POOL))
+#define GST_AJA_NVMM_BUFFER_POOL(obj) \
+    (G_TYPE_CHECK_INSTANCE_CAST((obj), GST_TYPE_AJA_NVMM_BUFFER_POOL, GstAjaNvmmBufferPool))
+#define GST_AJA_NVMM_BUFFER_POOL_CAST(obj) \
+    ((GstAjaNvmmBufferPool*)(obj))
+
+typedef struct _GstAjaNvmmBufferPool GstAjaNvmmBufferPool;
+typedef struct _GstAjaNvmmBufferPoolClass GstAjaNvmmBufferPoolClass;
+
+struct _GstAjaNvmmBufferPool
+{
+    // The NvmmBufferPool extends the NvDsBufferPool in order to allocate NVMM buffers.
+    GstNvDsBufferPool nvds_pool;
+};
+
+struct _GstAjaNvmmBufferPoolClass
+{
+    GstBufferPoolClass parent_class;
+};
+
+GType gst_aja_nvmm_buffer_pool_get_type (void);
+GstBufferPool * gst_aja_nvmm_buffer_pool_new (void);
+
+#endif // ENABLE_NVMM
 
 #endif

--- a/gst-plugin/aja/gstaja.h
+++ b/gst-plugin/aja/gstaja.h
@@ -1,6 +1,7 @@
 /* GStreamer
  * Copyright (C) 2015 PSM <philm@aja.com>
  * Copyright (C) 2017 Sebastian Dröge <sebastian@centricular.com>
+ * Copyright (C) 2021 NVIDIA Corporation.  All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -35,11 +36,15 @@ typedef enum
     GST_AJA_MODE_RAW_NTSC_8_2398i,
     GST_AJA_MODE_RAW_NTSC_8_24i,
     GST_AJA_MODE_RAW_NTSC_8_5994i,
+    GST_AJA_MODE_RAW_NTSC_8_RGBA_2398i,
+    GST_AJA_MODE_RAW_NTSC_8_RGBA_24i,
+    GST_AJA_MODE_RAW_NTSC_8_RGBA_5994i,
     GST_AJA_MODE_RAW_NTSC_10_2398i,
     GST_AJA_MODE_RAW_NTSC_10_24i,
     GST_AJA_MODE_RAW_NTSC_10_5994i,
     
     GST_AJA_MODE_RAW_PAL_8_50i,
+    GST_AJA_MODE_RAW_PAL_8_RGBA_50i,
     GST_AJA_MODE_RAW_PAL_10_50i,
     
     GST_AJA_MODE_RAW_720_8_2398p,
@@ -47,6 +52,11 @@ typedef enum
     GST_AJA_MODE_RAW_720_8_50p,
     GST_AJA_MODE_RAW_720_8_5994p,
     GST_AJA_MODE_RAW_720_8_60p,
+    GST_AJA_MODE_RAW_720_8_RGBA_2398p,
+    GST_AJA_MODE_RAW_720_8_RGBA_25p,
+    GST_AJA_MODE_RAW_720_8_RGBA_50p,
+    GST_AJA_MODE_RAW_720_8_RGBA_5994p,
+    GST_AJA_MODE_RAW_720_8_RGBA_60p,
     GST_AJA_MODE_RAW_720_10_2398p,
     GST_AJA_MODE_RAW_720_10_25p,
     GST_AJA_MODE_RAW_720_10_50p,
@@ -64,6 +74,18 @@ typedef enum
     GST_AJA_MODE_RAW_1080_8_5994p,
     GST_AJA_MODE_RAW_1080_8_60i,
     GST_AJA_MODE_RAW_1080_8_60p,
+
+    GST_AJA_MODE_RAW_1080_8_RGBA_2398p,
+    GST_AJA_MODE_RAW_1080_8_RGBA_24p,
+    GST_AJA_MODE_RAW_1080_8_RGBA_25p,
+    GST_AJA_MODE_RAW_1080_8_RGBA_2997p,
+    GST_AJA_MODE_RAW_1080_8_RGBA_30p,
+    GST_AJA_MODE_RAW_1080_8_RGBA_50i,
+    GST_AJA_MODE_RAW_1080_8_RGBA_50p,
+    GST_AJA_MODE_RAW_1080_8_RGBA_5994i,
+    GST_AJA_MODE_RAW_1080_8_RGBA_5994p,
+    GST_AJA_MODE_RAW_1080_8_RGBA_60i,
+    GST_AJA_MODE_RAW_1080_8_RGBA_60p,
     
     GST_AJA_MODE_RAW_1080_10_2398p,
     GST_AJA_MODE_RAW_1080_10_24p,
@@ -85,6 +107,15 @@ typedef enum
     GST_AJA_MODE_RAW_UHD_8_50p,
     GST_AJA_MODE_RAW_UHD_8_5994p,
     GST_AJA_MODE_RAW_UHD_8_60p,
+
+    GST_AJA_MODE_RAW_UHD_8_RGBA_2398p,
+    GST_AJA_MODE_RAW_UHD_8_RGBA_24p,
+    GST_AJA_MODE_RAW_UHD_8_RGBA_25p,
+    GST_AJA_MODE_RAW_UHD_8_RGBA_2997p,
+    GST_AJA_MODE_RAW_UHD_8_RGBA_30p,
+    GST_AJA_MODE_RAW_UHD_8_RGBA_50p,
+    GST_AJA_MODE_RAW_UHD_8_RGBA_5994p,
+    GST_AJA_MODE_RAW_UHD_8_RGBA_60p,
     
     GST_AJA_MODE_RAW_UHD_10_2398p,
     GST_AJA_MODE_RAW_UHD_10_24p,
@@ -107,6 +138,19 @@ typedef enum
     GST_AJA_MODE_RAW_4K_8_60p,
     GST_AJA_MODE_RAW_4K_8_11988p,
     GST_AJA_MODE_RAW_4K_8_120p,
+    
+    GST_AJA_MODE_RAW_4K_8_RGBA_2398p,
+    GST_AJA_MODE_RAW_4K_8_RGBA_24p,
+    GST_AJA_MODE_RAW_4K_8_RGBA_25p,
+    GST_AJA_MODE_RAW_4K_8_RGBA_2997p,
+    GST_AJA_MODE_RAW_4K_8_RGBA_30p,
+    GST_AJA_MODE_RAW_4K_8_RGBA_4795p,
+    GST_AJA_MODE_RAW_4K_8_RGBA_48p,
+    GST_AJA_MODE_RAW_4K_8_RGBA_50p,
+    GST_AJA_MODE_RAW_4K_8_RGBA_5994p,
+    GST_AJA_MODE_RAW_4K_8_RGBA_60p,
+    GST_AJA_MODE_RAW_4K_8_RGBA_11988p,
+    GST_AJA_MODE_RAW_4K_8_RGBA_120p,
     
     GST_AJA_MODE_RAW_4K_10_2398p,
     GST_AJA_MODE_RAW_4K_10_24p,
@@ -217,6 +261,7 @@ struct _GstAjaMode
     int                     width;
     int                     height;
     int                     bitDepth;
+    gboolean                isRGBA;
     int                     fps_n;
     int                     fps_d;
     gboolean                isInterlaced;

--- a/gst-plugin/aja/gstajavideosrc.cpp
+++ b/gst-plugin/aja/gstajavideosrc.cpp
@@ -1,6 +1,7 @@
 /* GStreamer
  * Copyright (C) 2015 PSM <philm@aja.com>
  * Copyright (C) 2017 Sebastian Dröge <sebastian@centricular.com>
+ * Copyright (C) 2021 NVIDIA Corporation.  All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -684,7 +685,7 @@ gst_aja_video_src_open (GstAjaVideoSrc * src)
       src->input->mode->bitDepth,
       src->input->mode->is422,
       false,
-      src->sdi_input_mode, timecode_mode, false, src->output_cc ? true : false,
+      src->sdi_input_mode, timecode_mode, src->output_cc ? true : false,
       src->passthrough ? true : false, src->capture_cpu_core);
   if (!AJA_SUCCESS (status)) {
     GST_ERROR_OBJECT (src, "Failed to initialize input");

--- a/gst-plugin/aja/gstajavideosrc.cpp
+++ b/gst-plugin/aja/gstajavideosrc.cpp
@@ -683,6 +683,7 @@ gst_aja_video_src_open (GstAjaVideoSrc * src)
   status = src->input->ntv2AV->Init (src->input->mode->videoFormat,
       input_source,
       src->input->mode->bitDepth,
+      src->input->mode->isRGBA,
       src->input->mode->is422,
       false,
       src->sdi_input_mode, timecode_mode, src->output_cc ? true : false,

--- a/gst-plugin/aja/gstajavideosrc.cpp
+++ b/gst-plugin/aja/gstajavideosrc.cpp
@@ -62,6 +62,7 @@ enum
   PROP_OUTPUT_CC,
   PROP_SIGNAL,
   PROP_CAPTURE_CPU_CORE,
+  PROP_NVMM
 };
 
 typedef enum {
@@ -237,6 +238,13 @@ gst_aja_video_src_class_init (GstAjaVideoSrcClass * klass)
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS |
               G_PARAM_CONSTRUCT)));
 
+#if ENABLE_NVMM
+  g_object_class_install_property (gobject_class, PROP_NVMM,
+      g_param_spec_boolean ("nvmm", "Use NVMM (NVIDIA GPU) Buffers",
+          "True if output frames should be output to NVMM (NVIDIA GPU) buffers via RDMA",
+          FALSE, (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+#endif
+
   templ_caps = gst_aja_mode_get_template_caps_raw ();
   gst_element_class_add_pad_template (element_class,
       gst_pad_template_new ("src", GST_PAD_SRC, GST_PAD_ALWAYS, templ_caps));
@@ -383,6 +391,12 @@ gst_aja_video_src_set_property (GObject * object, guint property_id,
       src->capture_cpu_core = g_value_get_uint (value);
       break;
 
+#if ENABLE_NVMM
+    case PROP_NVMM:
+      src->use_nvmm = g_value_get_boolean (value);
+      break;
+#endif
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
       break;
@@ -448,6 +462,12 @@ gst_aja_video_src_get_property (GObject * object, guint property_id,
     case PROP_CAPTURE_CPU_CORE:
       g_value_set_uint (value, src->capture_cpu_core);
       break;
+
+#if ENABLE_NVMM
+    case PROP_NVMM:
+      g_value_set_boolean (value, src->use_nvmm);
+      break;
+#endif
 
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -518,7 +538,7 @@ gst_aja_video_src_get_caps (GstBaseSrc * bsrc, GstCaps * filter)
   GstAjaVideoSrc *src = GST_AJA_VIDEO_SRC (bsrc);
   GstCaps *caps;
 
-  caps = gst_aja_mode_get_caps_raw (src->modeEnum);
+  caps = gst_aja_mode_get_caps_raw (src->modeEnum, src->use_nvmm);
   if (filter) {
     GstCaps *tmp = gst_caps_intersect_full (filter, caps, GST_CAPS_INTERSECT_FIRST);
     gst_caps_unref (caps);
@@ -609,6 +629,7 @@ gst_aja_video_src_open (GstAjaVideoSrc * src)
 {
   AJAStatus status;
   const GstAjaMode *mode;
+  GstCaps *caps;
   NTV2InputSource input_source;
   NTV2TCIndex timecode_mode;
 
@@ -624,6 +645,9 @@ gst_aja_video_src_open (GstAjaVideoSrc * src)
 
   mode = gst_aja_get_mode_raw (src->modeEnum);
   g_assert (mode != NULL);
+
+  caps = gst_aja_mode_get_caps_raw(src->modeEnum, src->use_nvmm);
+  g_assert (caps != NULL);
 
   g_mutex_lock (&src->input->lock);
   src->input->mode = mode;
@@ -687,7 +711,8 @@ gst_aja_video_src_open (GstAjaVideoSrc * src)
       src->input->mode->is422,
       false,
       src->sdi_input_mode, timecode_mode, src->output_cc ? true : false,
-      src->passthrough ? true : false, src->capture_cpu_core);
+      src->passthrough ? true : false, src->capture_cpu_core,
+      caps, src->use_nvmm);
   if (!AJA_SUCCESS (status)) {
     GST_ERROR_OBJECT (src, "Failed to initialize input");
     g_mutex_unlock (&src->input->lock);
@@ -1262,6 +1287,7 @@ gst_aja_video_src_create (GstPushSrc * bsrc, GstBuffer ** buffer)
 
   AjaCaptureVideoFrame f;
   GstCaps *caps;
+  GstCapsFeatures *features;
   GstClockTime capture_time, stream_time;
   gboolean timecode_valid;
   guint32 timecode_high, timecode_low;
@@ -1322,7 +1348,7 @@ retry:
     src->colorimetry = f.video_buff->colorimetry;
     src->fullRange = f.video_buff->fullRange;
     g_mutex_unlock (&src->lock);
-    caps = gst_aja_mode_get_caps_raw (f.mode);
+    caps = gst_aja_mode_get_caps_raw (f.mode, f.video_buff->isNvmm);
     gst_video_info_from_caps (&src->info, caps);
     // TODO: Work with videoinfo instead of caps
     gst_caps_unref (caps);
@@ -1357,6 +1383,10 @@ retry:
     }
     src->info.colorimetry.range = src->fullRange ? GST_VIDEO_COLOR_RANGE_0_255 : GST_VIDEO_COLOR_RANGE_16_235;
     caps = gst_video_info_to_caps (&src->info);
+    if (f.video_buff->isNvmm) {
+      features = gst_caps_features_new ("memory:NVMM", NULL);
+      gst_caps_set_features(caps, 0, features);
+    }
     gst_base_src_set_caps (GST_BASE_SRC_CAST (bsrc), caps);
     gst_element_post_message (GST_ELEMENT_CAST (src),
         gst_message_new_latency (GST_OBJECT_CAST (src)));

--- a/gst-plugin/aja/gstajavideosrc.h
+++ b/gst-plugin/aja/gstajavideosrc.h
@@ -1,6 +1,7 @@
 /* GStreamer
  * Copyright (C) 2015 PSM <philm@aja.com>
  * Copyright (C) 2017 Sebastian Dröge <sebastian@centricular.com>
+ * Copyright (C) 2021 NVIDIA Corporation.  All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -75,6 +76,7 @@ struct _GstAjaVideoSrc
     gboolean                    output_cc;
     gint			last_cc_vbi_line;
     guint                       capture_cpu_core;
+    gboolean                    use_nvmm;
 
     guint skipped_last;
     guint64 skipped_overall;

--- a/gst-plugin/aja/gstntv2.cpp
+++ b/gst-plugin/aja/gstntv2.cpp
@@ -21,6 +21,10 @@
 #include "ajabase/system/process.h"
 #include "ajabase/system/systemtime.h"
 
+#if ENABLE_NVMM
+#include "nvbufsurface.h"
+#endif
+
 GST_DEBUG_CATEGORY_STATIC (gst_ntv2_debug);
 #define GST_CAT_DEFAULT gst_ntv2_debug
 
@@ -54,6 +58,7 @@ mInputChannel (inChannel),
 mInputSource (NTV2_INPUTSOURCE_SDI1),
 mVideoFormat (NTV2_MAX_NUM_VIDEO_FORMATS),
 mMultiStream (false),
+mCaps (NULL),
 mAudioSystem (NTV2_AUDIOSYSTEM_1),
 mNumAudioChannels (0),
 mLastFrame (false),
@@ -180,7 +185,9 @@ AJAStatus
     const NTV2TCIndex inTimeCode,
     const bool inCaptureTall,
     const bool inPassthrough,
-    const uint32_t inCaptureCPUCore)
+    const uint32_t inCaptureCPUCore,
+    GstCaps *inCaps,
+    const bool inUseNvmm)
 {
   AJAStatus status (AJA_STATUS_SUCCESS);
 
@@ -196,6 +203,16 @@ AJAStatus
   mPassthrough = inPassthrough;
   mSDIInputMode = inSDIInputMode;
   mCaptureCPUCore = inCaptureCPUCore;
+  mCaps = inCaps;
+
+#if ENABLE_NVMM
+  mUseNvmm = inUseNvmm;
+#else
+  if (inUseNvmm) {
+    GST_ERROR ("NVMM RDMA Not Supported");
+    return AJA_STATUS_FAIL;
+  }
+#endif
 
   // Map input video modes. For quad-link and UHD/4k HDMI we need to map
   // to 4x modes, otherwise keep mode as is
@@ -1070,19 +1087,35 @@ NTV2GstAV::SetupHostBuffers (void)
   mAudioBufferSize = NTV2_AUDIOSIZE_MAX;
 
   mDevice.DMABufferAutoLock(false, true, 0);
-  GstAllocator *video_alloc = gst_aja_allocator_new(&mDevice, mVideoBufferSize, VIDEO_ARRAY_SIZE);
 
   // These video buffers are actually passed out of this class so we need to assign them unique numbers
   // so they can be tracked and also they have a state
-  mVideoBufferPool = gst_aja_buffer_pool_new ();
-  GstStructure *config = gst_buffer_pool_get_config (mVideoBufferPool);
-  gst_buffer_pool_config_set_params (config, NULL, mVideoBufferSize,
-      VIDEO_ARRAY_SIZE, 0);
-  gst_buffer_pool_config_set_allocator (config, video_alloc, NULL);
-  gst_structure_set (config, "is-video", G_TYPE_BOOLEAN, TRUE, NULL);
-  gst_buffer_pool_set_config (mVideoBufferPool, config);
-  gst_buffer_pool_set_active (mVideoBufferPool, TRUE);
-  gst_object_unref (video_alloc);
+  GstStructure *config;
+#if ENABLE_NVMM
+  if (mUseNvmm) {
+    mVideoBufferPool = gst_aja_nvmm_buffer_pool_new ();
+    config = gst_buffer_pool_get_config (mVideoBufferPool);
+    gst_buffer_pool_config_set_params (config, mCaps, mVideoBufferSize,
+        VIDEO_ARRAY_SIZE, 0);
+
+    gst_buffer_pool_set_config (mVideoBufferPool, config);
+    gst_buffer_pool_set_active (mVideoBufferPool, TRUE);
+  } else
+#endif
+  {
+    GstAllocator *video_alloc = gst_aja_allocator_new(&mDevice, mVideoBufferSize, VIDEO_ARRAY_SIZE);
+
+    mVideoBufferPool = gst_aja_buffer_pool_new ();
+    config = gst_buffer_pool_get_config (mVideoBufferPool);
+    gst_buffer_pool_config_set_params (config, NULL, mVideoBufferSize,
+        VIDEO_ARRAY_SIZE, 0);
+    gst_buffer_pool_config_set_allocator (config, video_alloc, NULL);
+    gst_structure_set (config, "is-video", G_TYPE_BOOLEAN, TRUE, NULL);
+
+    gst_buffer_pool_set_config (mVideoBufferPool, config);
+    gst_buffer_pool_set_active (mVideoBufferPool, TRUE);
+    gst_object_unref (video_alloc);
+  }
 
   GstAllocator *audio_alloc = gst_aja_allocator_new(&mDevice, mAudioBufferSize, AUDIO_ARRAY_SIZE);
   mAudioBufferPool = gst_aja_buffer_pool_new ();
@@ -1483,8 +1516,19 @@ NTV2GstAV::ACInputWorker (void)
 
       if (pVideoData->buffer) {
         gst_buffer_map (pVideoData->buffer, &video_map, GST_MAP_READWRITE);
-        pVideoData->pVideoBuffer = (uint32_t *) video_map.data;
-        pVideoData->videoBufferSize = video_map.size;
+#if ENABLE_NVMM
+        if (pVideoData->isNvmm) {
+          NvBufSurface *surf = (NvBufSurface*)video_map.data;
+          pVideoData->pVideoBuffer = (uint32_t *) surf->surfaceList[0].dataPtr;
+          pVideoData->videoBufferSize = surf->surfaceList[0].dataSize;
+          // Lock the buffer for RDMA
+          mDevice.DMABufferLock(pVideoData->pVideoBuffer, pVideoData->videoBufferSize, false, true);
+        } else
+#endif
+        {
+          pVideoData->pVideoBuffer = (uint32_t *) video_map.data;
+          pVideoData->videoBufferSize = video_map.size;
+        }
       }
       mInputTransferStruct.SetVideoBuffer (pVideoData->pVideoBuffer,
           pVideoData->videoBufferSize);
@@ -1501,6 +1545,15 @@ NTV2GstAV::ACInputWorker (void)
 
       // do the transfer from the device into our host AvaDataBuffer...
       mDevice.AutoCirculateTransfer (mInputChannel, mInputTransferStruct);
+
+#if ENABLE_NVMM
+      if (pVideoData->isNvmm) {
+        // Unlock from RDMA
+        mDevice.DMABufferUnlock(pVideoData->pVideoBuffer, pVideoData->videoBufferSize);
+        NvBufSurface *surf = (NvBufSurface*)video_map.data;
+        surf->numFilled = 1;
+      }
+#endif
 
       // get the video data size
       pVideoData->videoDataSize = pVideoData->videoBufferSize;
@@ -1537,8 +1590,10 @@ NTV2GstAV::ACInputWorker (void)
         GST_DEBUG ("offset %" G_GSIZE_FORMAT, offset);
         GST_DEBUG ("videoDataSize %u", pVideoData->videoDataSize);
         gst_buffer_unmap (pVideoData->buffer, &video_map);
-        gst_buffer_resize (pVideoData->buffer, offset,
-            pVideoData->videoDataSize - offset);
+        if (!pVideoData->isNvmm) {
+          gst_buffer_resize (pVideoData->buffer, offset,
+              pVideoData->videoDataSize - offset);
+        }
         pVideoData->pAncillaryData = validVanc ? pVideoData->pVideoBuffer : NULL;
         pVideoData->pVideoBuffer = NULL;
       }

--- a/gst-plugin/aja/gstntv2.h
+++ b/gst-plugin/aja/gstntv2.h
@@ -50,6 +50,8 @@ typedef struct
 {
     GstBuffer *     buffer;                 /// If buffer != NULL, it actually owns the AjaVideoBuff and the following 3 fields are NULL
 
+    bool            isNvmm;                 /// True if this is an NVIDIA NVMM GPU Buffer used with RDMA
+
     uint32_t *      pVideoBuffer;           /// Pointer to host video buffer
     uint32_t        videoBufferSize;        /// Size of host video buffer (bytes)
     uint32_t        videoDataSize;          /// Size of video data (bytes)
@@ -150,7 +152,9 @@ class NTV2GstAV
                                 const NTV2TCIndex               inTimeCode      = NTV2_TCINDEX_SDI1,
 				const bool                      inCaptureTall   = false,
                                 const bool                      inPassthrough   = false,
-                                const uint32_t                  inCaptureCPUCore = -1);
+                                const uint32_t                  inCaptureCPUCore = -1,
+                                GstCaps                        *inCaps          = NULL,
+                                const bool                      inUseNvmm       = false);
 
         virtual AJAStatus InitAudio (const NTV2AudioSource inAudioSource, uint32_t *numAudioChannels);
 
@@ -290,6 +294,8 @@ class NTV2GstAV
         uint32_t                    mCaptureCPUCore;
         NTV2InputSource             mVideoSource;
         bool                        mPassthrough;
+        GstCaps *                   mCaps;                  /// GStreamer format caps, used by buffer pools/allocators
+        bool                        mUseNvmm;               /// Outputs NVMM buffers via RDMA, otherwise outputs regular sysmem buffers
         NTV2AudioSystem             mAudioSystem;            ///    The audio system I'm using
         NTV2AudioSource             mAudioSource;
         uint32_t                    mNumAudioChannels;

--- a/gst-plugin/aja/gstntv2.h
+++ b/gst-plugin/aja/gstntv2.h
@@ -3,6 +3,7 @@
     @brief        Declares the NTV2Capture class.
     @copyright    Copyright (C) 2012-2015 AJA Video Systems, Inc.  All rights reserved.
                   Copyright (C) 2017 Sebastian Dröge <sebastian@centricular.com>
+                  Copyright (C) 2021 NVIDIA Corporation.  All rights reserved.
 **/
 
 
@@ -142,6 +143,7 @@ class NTV2GstAV
         virtual AJAStatus Init (const NTV2VideoFormat           inVideoFormat   = NTV2_FORMAT_525_5994,
                                 const NTV2InputSource           inInputSource   = NTV2_INPUTSOURCE_SDI1,
                                 const uint32_t                  inBitDepth      = 8,
+                                const bool                      inIsRGBA        = false,
                                 const bool                      inIs422         = false,
                                 const bool                      inIsAuto        = false,
                                 const SDIInputMode              inSDIInputMode  = SDI_INPUT_MODE_SINGLE_LINK,
@@ -277,6 +279,7 @@ class NTV2GstAV
         NTV2VideoFormat                mVideoFormat;            ///    Video format
         NTV2FrameBufferFormat        mPixelFormat;            ///    Pixel format
         uint32_t                    mBitDepth;              /// Bit depth of frame store (8 or 10)
+        bool                        mIsRGBA;                /// Is RGBA, otherwise it is YUV
         bool                        mIs422;                    /// Is 422 video otherwise it is 420
         bool                        mIsAuto;                /// Is auto mode (should only be used when called from the audiosrc to set device automatically based on input)
         SDIInputMode                mSDIInputMode;           /// SDI input mode

--- a/gst-plugin/configure.ac
+++ b/gst-plugin/configure.ac
@@ -84,6 +84,14 @@ dnl set proper LDFLAGS for plugins
 GST_PLUGIN_LDFLAGS='-module -avoid-version -export-symbols-regex [_]*\(gst_\|Gst\|GST_\).*'
 AC_SUBST(GST_PLUGIN_LDFLAGS)
 
+dnl check for GST_DEEPSTREAM and GST_CUDA to enable NVMM (NvBuffer) RDMA support
+AM_CONDITIONAL([ENABLE_NVMM], [test ! -z "$GST_DEEPSTREAM"])
+if [test ! -z "$GST_DEEPSTREAM"] && [test -z "$GST_CUDA"]; then
+  AC_MSG_ERROR([
+      GST_DEEPSTREAM and GST_CUDA must both be set to enable NVMM RDMA support.
+  ])
+fi
+
 AC_CONFIG_FILES([Makefile aja/Makefile])
 AC_OUTPUT
 


### PR DESCRIPTION
This enables RDMA to NVIDIA GPU buffers via the GStreamer 'NVMM' memory type that is used by NVIDIA authored GStreamer plugins (such as those included with DeepStream). This support depends on NVIDIA CUDA and the DeepStream SDK, which provides the GstNvDsBufferPool buffer allocator and NvBufSurface buffer descriptor in order to access the allocated GPU buffers.

RGBA framebuffer formats have also been added since the NVIDIA plugins do not support packed YUV formats.

Using this feature requires version 16.1 of the NTV2 SDK, built using the AJA_RDMA option enabled.